### PR TITLE
Filter rework

### DIFF
--- a/app.R
+++ b/app.R
@@ -49,6 +49,8 @@ ipak(packages)
 
 #source("sources/Settings.R")
 
+    tab_selected = "Wachusett"
+
 ### Load Primary Modules
 
 source("modules1/home.R")
@@ -140,43 +142,6 @@ tabPanel("Home",
 ),
 
 
-####################################################################
-# Filter
-
-tabPanel("Filter",
-
-         # Title
-
-         fluidRow(
-                  column(2, imageOutput("wave_image2", height = 50), align = "center"),
-                  column(10, h2("Filter Data", align = "center"))
-                  ),
-         navlistPanel(widths = c(2, 10),
-                      "Water Quality Data",
-                      tabPanel("Tributary",
-                               fluidRow(h4("Filter Tributary WQ Data", align = "center")),
-                               FILTER_WQ_UI("mod_trib_filter")
-                      ),
-                      tabPanel("Bacteria (Res)",
-                               fluidRow(h4("Filter Reservoir Bacteria WQ Data", align = "center")),
-                               FILTER_WQ_UI("mod_bact_filter")
-                      ),
-                      tabPanel("Chemical (Res)",
-                               fluidRow(h4("Filter Reservoir Chemical WQ Data", align = "center")),
-                               FILTER_WQ_UI("mod_chem_filter")
-                      ),
-                      tabPanel("Profile (Res)",
-                               fluidRow(h4("Filter Reservoir Profile WQ Data", align = "center")),
-                               FILTER_WQ_UI("mod_prof_filter")
-                      ),
-                      "Hydro and Met",
-                      tabPanel("Hydro/Met Data",
-                               fluidRow(h4("Filter Hydro and Met Data", align = "center"))
-                      )
-         ) # end navlist
-),
-
-
 ######################################################
 # Tributary Water Quality Data
 
@@ -188,42 +153,52 @@ tabPanel("Tributary",
            column(2, imageOutput("wave_image3", height = 50), align = "center"),
            column(10, h2("Tributary Water Quality Data", align = "center"))
   ),
-  navlistPanel(widths = c(2, 10),
-               tabPanel("Time-Series",
-                        fluidRow(h4("Tributary Time-Series Analysis", align = "center")),
-                        tabsetPanel(
-                          tabPanel("Quabbin", TIME_WQ_UI("mod_trib_quab_time")),
-                          tabPanel("Ware River", TIME_WQ_UI("mod_trib_ware_time")),
-                          tabPanel("Wachusett", TIME_WQ_UI("mod_trib_wach_time"))#,
-                          #tabPanel("All Tribs", time_UI("mod_trib_all_time"))
-                        ) # end tabset Panel
-               ), # end tabpanel
-               tabPanel("Correlation",
-                        fluidRow(h4("Tributary Correlation Analysis", align = "center")),
-                        tabsetPanel(
-                          tabPanel("Quabbin", CORRELATION_WQ_UI("mod_trib_quab_corr")),
-                          tabPanel("Ware River", CORRELATION_WQ_UI("mod_trib_ware_corr")),
-                          tabPanel("Wachusett", CORRELATION_WQ_UI("mod_trib_wach_corr"))#,
-                          #tabPanel("All Tribs", CORRELATION_WQ_UI("mod_trib_all_corr"))
-                        ) # end tabset Panel
-               ), # end tabpanel
-               tabPanel("Distribution",
-                        fluidRow(h4("Tributary Parameter Value Distribution", align = "center")),
-                        tabsetPanel(
-                          tabPanel("Quabbin", DISTRIBUTION_WQ_UI("mod_trib_quab_dist")),
-                          tabPanel("Ware River", DISTRIBUTION_WQ_UI("mod_trib_ware_dist")),
-                          tabPanel("Wachusett", DISTRIBUTION_WQ_UI("mod_trib_wach_dist"))#,
-                          #tabPanel("All Tribs", CORRELATION_WQ_UI("mod_trib_all_corr"))
-                        ) # end tabset Panel
-               ), # end tabpanel
-               tabPanel("MetaData",
-                        fluidRow(h4("Tributary MetaData", align = "center")),
-                        tabsetPanel(
-                          tabPanel("Quabbin & Ware", METADATA_UI("mod_trib_quab_meta")),
-                          tabPanel("Wachusett", METADATA_UI("mod_trib_wach_meta"))
-                        ) # end tabset Panel
-               ) # end tabpanel
-  ) # end navlist panel
+  tabsetPanel(
+    tabPanel("Quabbin",
+             navlistPanel(widths = c(2, 10),
+                          tabPanel("Select / Filter data", FILTER_WQ_UI("mod_trib_quab_filter")),
+                          tabPanel("-- table", fluidRow(h5("Table to come"))
+                          ),
+                          tabPanel("-- plots",
+                                   tabsetPanel(
+                                     tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_trib_quab_plot_time")),
+                                     tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_trib_quab_plot_corr")),
+                                     tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_trib_quab_plot_dist"))
+                                   )
+                          ),
+                          tabPanel("-- statistics",
+                                   tabsetPanel(
+                                     tabPanel("Summary Statistics", STAT_TIME_WQ_UI("mod_trib_quab_stat_sum")),
+                                     tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                     tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_trib_quab_stat_cormat"))
+                                   )
+                          ),
+                          tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_quab_map", df = df_trib_quab)),
+                          tabPanel("Metadata", METADATA_UI("mod_trib_quab_meta"))
+             ) # end navlist panel
+    ),
+    tabPanel("Ware",
+             navlistPanel(widths = c(2, 10),
+                          tabPanel("SELECT / FILTER DATA", FILTER_WQ_UI("mod_trib_ware_filter")),
+                          tabPanel("- table", TIME_WQ_UI("mod_trib_ware_time")),
+                          tabPanel("- plots", CORRELATION_WQ_UI("mod_trib_ware_corr")),
+                          tabPanel("- statistics", DISTRIBUTION_WQ_UI("mod_trib_ware_dist")),
+                          tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_ware_map", df = df_trib_ware)),
+                          tabPanel("Metadata", fluidRow(h5("See Quabbin Tab. Can add data here in future")))
+             ) # end navlist panel
+    ),
+    tabPanel("Wachusett",
+             navlistPanel(widths = c(2, 10),
+                          tabPanel("SELECT / FILTER DATA", FILTER_WQ_UI("mod_trib_wach_filter")),
+                          tabPanel("- table", TIME_WQ_UI("mod_trib_wach_time")),
+                          tabPanel("- plots", CORRELATION_WQ_UI("mod_trib_wach_corr")),
+                          tabPanel("- statistics", DISTRIBUTION_WQ_UI("mod_trib_wach_dist")),
+                          tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_wach_map", df = df_trib_quab)),
+                          tabPanel("- MetaData", METADATA_UI("mod_trib_wach_meta"))
+             ) # end navlist panel
+    ),
+    selected = tab_selected
+  )
 
 ), # end Tributary tabpanel (page)
 
@@ -240,6 +215,12 @@ tabPanel("Reservoir",
    ),
    navlistPanel(widths = c(2, 10),
                 "Bacteria",
+                tabPanel("SelectFilter Data",
+                         fluidRow(h4("Select and Filter Data", align = "center")),
+                         tabsetPanel(
+                           tabPanel("Wachusett", FILTER_WQ_UI("mod_bact_wach_filter"))
+                         ) # end tabset Panel
+                ), # end tabpanel
                 tabPanel("Time-Series",
                          fluidRow(h4("Bacteria Time-Series Analysis", align = "center")),
                          tabsetPanel(
@@ -259,7 +240,14 @@ tabPanel("Reservoir",
                          ) # end tabset Panel
                 ), # end tabpanel
 
-                "Chemistry",
+                "Chemical",
+                tabPanel("SelectFilter Data",
+                         fluidRow(h4("Select and Filter Data", align = "center")),
+                         tabsetPanel(
+                           tabPanel("Quabbin", FILTER_WQ_UI("mod_chem_quab_filter")),
+                           tabPanel("Wachusett", FILTER_WQ_UI("mod_chem_wach_filter"))
+                         ) # end tabset Panel
+                ), # end tabpanel
                 tabPanel("Time-Series",
                          fluidRow(h4("Chemical Time-Series Analysis", align = "center")),
                          tabsetPanel(
@@ -282,7 +270,7 @@ tabPanel("Reservoir",
                          ) # end tabset Panel
                 ), # end tabpanel
 
-                "Profile (physicochemical)",
+                "Profile",
                 tabPanel("Heat Map",
                          fluidRow(h4("Profile Heatmap", align = "center")),
                          tabsetPanel(
@@ -337,11 +325,6 @@ tabPanel("Map Plot",
                   column(10, h2("Geospatial Plots", align = "center"))
          ),
          navlistPanel(widths = c(2, 10),
-                      "Tributaries",
-                      tabPanel("Quabbin", MAP_PLOT_UI("mod_trib_quab_map", df = df_trib_quab)),
-                      tabPanel("Ware River", MAP_PLOT_UI("mod_trib_ware_map", df = df_trib_ware)),
-                      tabPanel("Wachusett", MAP_PLOT_UI("mod_trib_wach_map", df = df_trib_wach)),
-                      tabPanel("All Tribs", MAP_PLOT_UI("mod_trib_all_map", df = df_trib_all)),
                       "Reservoir Bacteria",
                       tabPanel("Wachusett", MAP_PLOT_UI("mod_bact_wach_map", df = df_bact_wach)),
                       "Reservoir Chemical",
@@ -454,61 +437,93 @@ server <- function(input, output, session) {
 
   callModule(HOME, "home", df_site = df_all_site)
 
-###################################################################
-# Filter
-
-  Df_Trib_Filtered <- callModule(FILTER_WQ, "mod_trib_filter", dfs = list(df_trib_wach, df_trib_quab, df_trib_ware))
-  Df_Bact_Filtered <- callModule(FILTER_WQ, "mod_bact_filter", dfs = list(df_bact_wach))
-  Df_Chem_Filtered <- callModule(FILTER_WQ, "mod_chem_filter", dfs = list(df_chem_wach, df_chem_quab))
-  Df_Prof_Filtered <- callModule(FILTER_WQ, "mod_prof_filter", dfs = list(df_prof_quab, df_prof_wach))  # fix site
-
 
 ######################################################
 # Tributary
 
+  ### Quabbin
+
+  # Filter
+  Df_Trib_Quab <- callModule(FILTER_WQ, "mod_trib_quab_filter", df = df_trib_quab, df_site = df_trib_quab_site)
+
+  # Table
+
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_trib_quab_plot_time", Df = Df_Trib_Quab$Long)
+  callModule(PLOT_CORR_WQ, "mod_trib_quab_plot_corr", Df = Df_Trib_Quab$Long)
+  callModule(DISTRIBUTION_WQ, "mod_trib_quab_plot_dist", Df = Df_Trib_Quab$Long)
+
+  # Stats
+  callModule(STAT_TIME_WQ, "mod_trib_quab_stat_sum", Df = Df_Trib_Quab$Long)  # Push in $Stats and get rid in module
+  #callModule(STAT_TIME_WQ, "mod_trib_quab_stat_temp", Df = Df_Trib_Quab)
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_trib_quab_stat_cormat", Df = Df_Trib_Quab$Wide)
+
+  # Geospatial
+  callModule(MAP_PLOT, "mod_trib_quab_map", df = df_trib_quab, df_site = df_trib_quab_site)
+
+  # MetaData
+  callModule(METADATA, "mod_trib_quab_meta", df = df_trib_quab, df_site = df_trib_quab_site, df_param = df_quab_param)
+
+
+  ### Ware
+  ### Wachusett
+
+  # Select/Filter Data - Returns a list of 3 versions of reactive filtered dataframes (Long, Wide, Stat)
+
+  Df_Trib_Ware <- callModule(FILTER_WQ, "mod_trib_ware_filter", df = df_trib_ware, df_site = df_trib_ware_site)
+  Df_Trib_Wach <- callModule(FILTER_WQ, "mod_trib_wach_filter", df = df_trib_wach, df_site = df_trib_wach_site)
+
   # Time Series
-  callModule(TIME_WQ, "mod_trib_quab_time", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site)
-  callModule(TIME_WQ, "mod_trib_ware_time", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
-  callModule(TIME_WQ, "mod_trib_wach_time", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
+  callModule(TIME_WQ, "mod_trib_ware_time", Df = Df_Trib_Ware$Long)
+  callModule(TIME_WQ, "mod_trib_wach_time", Df = Df_Trib_Wach$Long)
   #callModule(time, "mod_trib_all_time", df = df_trib_all, df_site = df_trib_all_site)
 
   # Correlation
-  callModule(CORRELATION_WQ, "mod_trib_quab_corr", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site)
-  callModule(CORRELATION_WQ, "mod_trib_ware_corr", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
-  callModule(CORRELATION_WQ, "mod_trib_wach_corr", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
+  callModule(CORRELATION_WQ, "mod_trib_ware_corr", Dfa = Df_Trib_Ware$Long, Dfb = Df_Trib_Ware$Wide)
+  callModule(CORRELATION_WQ, "mod_trib_wach_corr", Dfa = Df_Trib_Wach$Long, Dfb = Df_Trib_Wach$Wide)
   #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
 
   # Distribution
-  callModule(DISTRIBUTION_WQ, "mod_trib_quab_dist", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site)
-  callModule(DISTRIBUTION_WQ, "mod_trib_ware_dist", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
-  callModule(DISTRIBUTION_WQ, "mod_trib_wach_dist", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
+  callModule(DISTRIBUTION_WQ, "mod_trib_ware_dist", Df = Df_Trib_Ware$Stat)
+  callModule(DISTRIBUTION_WQ, "mod_trib_wach_dist", Df = Df_Trib_Wach$Stat)
   #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
 
   # Metadata
-  callModule(METADATA, "mod_trib_quab_meta", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site, df_param = df_quab_param)
-  callModule(METADATA, "mod_trib_wach_meta", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site, df_param = df_wq_wach_param, df_flag = df_wq_wach_flag)
+  callModule(METADATA, "mod_trib_wach_meta", df = df_trib_wach, df_site = df_trib_wach_site, df_param = df_wq_wach_param)
 
 #############################################################
 # Reservoir
 
-  # Bacteria
-  callModule(TIME_WQ, "mod_bact_wach_time", df_full = df_bact_wach, Df_Filtered = Df_Bact_Filtered[[1]], df_site = df_bact_wach_site)
+  ### Bacteria
 
-  callModule(CORRELATION_WQ, "mod_bact_wach_corr", df_full = df_bact_wach, Df_Filtered = Df_Bact_Filtered[[1]], df_site = df_bact_wach_site)
+  # Filter
+  Df_Bact_Wach <- callModule(FILTER_WQ, "mod_bact_wach_filter", df = df_bact_wach, df_site = df_bact_wach_site)
 
-  callModule(METADATA, "mod_bact_wach_meta", df_full = df_bact_wach, Df_Filtered = Df_Bact_Filtered[[1]], df_site = df_bact_wach_site, df_param = df_wq_wach_param, df_flag = df_wq_wach_flag)
+  callModule(TIME_WQ, "mod_bact_wach_time", Df = Df_Bact_Wach$Long)
 
-  # Chemical
-  callModule(TIME_DEPTH_WQ, "mod_chem_quab_time", df_full = df_chem_quab, Df_Filtered = Df_Chem_Filtered[[2]], df_site = df_chem_quab_site)
-  callModule(TIME_DEPTH_WQ, "mod_chem_wach_time", df_full = df_chem_wach, Df_Filtered = Df_Chem_Filtered[[1]], df_site = df_chem_wach_site)
+  callModule(CORRELATION_WQ, "mod_bact_wach_corr", Dfa = Df_Bact_Wach$Long, Dfb = Df_Bact_Wach$Wide)
 
+  callModule(METADATA, "mod_bact_wach_meta", df_bact_wach, df_site = df_bact_wach_site, df_param = df_wq_wach_param)
+
+  ### Chemical
+
+  # Filter
+  Df_Chem_Quab <- callModule(FILTER_WQ, "mod_chem_quab_filter", df = df_chem_quab, df_site = df_chem_quab_site, depth = TRUE)
+  Df_Chem_Wach <- callModule(FILTER_WQ, "mod_chem_wach_filter", df = df_chem_wach, df_site = df_chem_wach_site, depth = TRUE)
+
+  # Time-Series
+  callModule(TIME_DEPTH_WQ, "mod_chem_quab_time", Df = Df_Chem_Quab$Long)
+  callModule(TIME_DEPTH_WQ, "mod_chem_wach_time", Df = Df_Chem_Wach$Long)
+
+  # Correlation
   callModule(CORRELATION_DEPTH_WQ, "mod_chem_quab_corr", df = df_chem_quab, df_site = df_chem_quab_site)
   callModule(CORRELATION_DEPTH_WQ, "mod_chem_wach_corr", df = df_chem_wach, df_site = df_chem_wach_site)
 
-  callModule(METADATA, "mod_chem_quab_meta", df_full = df_chem_quab, Df_Filtered = Df_Chem_Filtered[[2]], df_site = df_chem_quab_site, df_param = df_quab_param)
-  callModule(METADATA, "mod_chem_wach_meta",  df_full = df_chem_wach, Df_Filtered = Df_Chem_Filtered[[1]], df_site = df_prof_wach_site)
+  # Metadata
+  callModule(METADATA, "mod_chem_quab_meta",  df = df_chem_quab, df_site = df_chem_quab_site, df_param = df_quab_param)
+  callModule(METADATA, "mod_chem_wach_meta",  df = df_chem_wach, df_site = df_chem_wach_site)
 
-  # Profile (physicochemical)
+  ### Profile (physicochemical)
   callModule(PROF_HEATMAP, "mod_prof_quab_heat", df = df_prof_quab)
   callModule(PROF_HEATMAP, "mod_prof_wach_heat", df = df_prof_wach)
 
@@ -519,8 +534,8 @@ server <- function(input, output, session) {
   callModule(PROF_TABLE_STAT, "mod_prof_wach_sum", df = df_prof_wach)
 
   # Change the Data Frames to Profile Data
-  callModule(METADATA, "mod_prof_quab_meta", df_full = df_chem_quab, Df_Filtered = Df_Chem_Filtered[[2]], df_site = df_prof_quab_site, df_param = df_quab_param)
-  callModule(METADATA, "mod_prof_wach_meta", df_full = df_chem_wach, Df_Filtered = Df_Chem_Filtered[[1]], df_site = df_prof_wach_site)
+  callModule(METADATA, "mod_prof_quab_meta", df = df_prof_quab, df_site = df_prof_quab_site, df_param = df_quab_param)
+  callModule(METADATA, "mod_prof_wach_meta", df = df_prof_wach, df_site = df_prof_wach_site)
 
   # AquaBio
   callModule(PHYTO, "mod_phyto_wach_plots", df = df_phyto_wach)
@@ -530,17 +545,16 @@ server <- function(input, output, session) {
 # Map Plot
 
   # Trib
-  callModule(MAP_PLOT, "mod_trib_quab_map", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site)
-  callModule(MAP_PLOT, "mod_trib_ware_map", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
-  callModule(MAP_PLOT, "mod_trib_wach_map", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
-  callModule(MAP_PLOT, "mod_trib_all_map", df_full = df_trib_all, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_all_site)
+
+  callModule(MAP_PLOT, "mod_trib_ware_map", df = df_trib_ware, df_site = df_trib_ware_site)
+  callModule(MAP_PLOT, "mod_trib_wach_map", df = df_trib_wach, df_site = df_trib_wach_site)
 
   # Bacteria
-  callModule(MAP_PLOT, "mod_bact_wach_map", df_full = df_bact_wach, Df_Filtered = Df_Bact_Filtered[[1]], df_site = df_bact_wach_site)
+  callModule(MAP_PLOT, "mod_bact_wach_map", df = df_bact_wach, df_site = df_bact_wach_site)
 
   # Chemical
-  callModule(MAP_PLOT, "mod_chem_quab_map", df_full = df_chem_quab, Df_Filtered = Df_Chem_Filtered[[2]], df_site = df_chem_quab_site)
-  callModule(MAP_PLOT, "mod_chem_wach_map", df_full = df_chem_wach, Df_Filtered = Df_Chem_Filtered[[1]], df_site = df_chem_wach_site)
+  callModule(MAP_PLOT, "mod_chem_quab_map", df = df_chem_quab, df_site = df_chem_quab_site)
+  callModule(MAP_PLOT, "mod_chem_wach_map", df = df_chem_wach, df_site = df_chem_wach_site)
 
 ####################################################################
 # Hydrology/Meteorology/Statistics

--- a/app.R
+++ b/app.R
@@ -112,7 +112,7 @@ source("functions/phyto_plots.R")
 #               font-family: 'Lobster', cursive;
 ui <- tagList(
   # Creates padding at top for navBar space due to "fixed-top" position
-  tags$style(type='text/css', 
+  tags$style(type='text/css',
              'body {padding-top: 70px;}',
              'h2 {
                font-family: "Arial Black";
@@ -121,15 +121,15 @@ ui <- tagList(
                color: #0C4B91;
              }'
              ),
-  
-  navbarPage(NULL, position = "fixed-top", inverse = TRUE, collapsible = TRUE, theme = shinytheme("cerulean"), 
+
+  navbarPage(NULL, position = "fixed-top", inverse = TRUE, collapsible = TRUE, theme = shinytheme("cerulean"),
              windowTitle = "WAVE", footer = uiOutput("footer_ui"),
 
 ######################################################
 # Home Page
 
 tabPanel("Home",
-         
+
          fluidRow(
            column(3, imageOutput("dcr_image", height = 80), align = "left"),
            column(6, imageOutput("wave_image1", height = 80), align = "center"),
@@ -182,7 +182,7 @@ tabPanel("Filter",
 
 tabPanel("Tributary",
 
-         
+
   # Title
   fluidRow(
            column(2, imageOutput("wave_image3", height = 50), align = "center"),
@@ -232,7 +232,7 @@ tabPanel("Tributary",
 # Reservoir
 
 tabPanel("Reservoir",
-         
+
    # Title
    fluidRow(
             column(2, imageOutput("wave_image4", height = 50), align = "center"),
@@ -330,7 +330,7 @@ tabPanel("Reservoir",
 # Map
 
 tabPanel("Map Plot",
-         
+
          # Title
          fluidRow(
                   column(2, imageOutput("wave_image5", height = 50), align = "center"),
@@ -356,7 +356,7 @@ tabPanel("Map Plot",
 # Hydrology/Meteorology
 
 tabPanel("Met/Hydro",
-         
+
          # Title
          fluidRow(
                   column(2, imageOutput("wave_image6", height = 50), align = "center"),
@@ -368,7 +368,7 @@ tabPanel("Met/Hydro",
 # Forestry
 
 tabPanel("Forestry",
-         
+
          # Title
          fluidRow(
                   column(2, imageOutput("wave_image7", height = 50), align = "center"),
@@ -380,7 +380,7 @@ tabPanel("Forestry",
 # Reports
 
 tabPanel("Report",
-         
+
          # Title
          fluidRow(
                   column(2, imageOutput("wave_image8", height = 50), align = "center"),
@@ -477,13 +477,13 @@ server <- function(input, output, session) {
   callModule(CORRELATION_WQ, "mod_trib_ware_corr", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
   callModule(CORRELATION_WQ, "mod_trib_wach_corr", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
   #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
-  
+
   # Distribution
   callModule(DISTRIBUTION_WQ, "mod_trib_quab_dist", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site)
   callModule(DISTRIBUTION_WQ, "mod_trib_ware_dist", df_full = df_trib_ware, Df_Filtered = Df_Trib_Filtered[[3]], df_site = df_trib_ware_site)
   callModule(DISTRIBUTION_WQ, "mod_trib_wach_dist", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site)
   #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
-  
+
   # Metadata
   callModule(METADATA, "mod_trib_quab_meta", df_full = df_trib_quab, Df_Filtered = Df_Trib_Filtered[[2]], df_site = df_trib_quab_site, df_param = df_quab_param)
   callModule(METADATA, "mod_trib_wach_meta", df_full = df_trib_wach, Df_Filtered = Df_Trib_Filtered[[1]], df_site = df_trib_wach_site, df_param = df_wq_wach_param, df_flag = df_wq_wach_flag)
@@ -563,13 +563,13 @@ server <- function(input, output, session) {
 
 #######################################################################
 # Footer
-  
+
   output$footer_ui <- renderUI({
-    
+
     update_date <- "Coming Soon"
-    
+
     text_db <- paste("Data last updated:", update_date)
-    
+
     tagList(
       hr(),
       column(4,
@@ -582,88 +582,88 @@ server <- function(input, output, session) {
       )
     )
   })
-  
+
 #######################################################################
 # Images
-  
+
   # DCR IMAGE
   output$dcr_image <- renderImage({
     list(src = "images/DCR.jpg",
          width= "160",
          height= "80")
   }, deleteFile = FALSE)
-  
+
   # UMass IMAGE
   output$umass_image <- renderImage({
     list(src = "images/UMass.png",
          width= "240",
          height= "80")
   }, deleteFile = FALSE)
-  
+
   # WAVE IMAGE 1
   output$wave_image1 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "360",
          height= "80")
   }, deleteFile = FALSE)
-  
+
   # WAVE IMAGE 2
   output$wave_image2 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
+
   # WAVE IMAGE 3
   output$wave_image3 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
+
   # WAVE IMAGE 4
   output$wave_image4 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
+
   # WAVE IMAGE 5
   output$wave_image5 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
-  
+
+
   # WAVE IMAGE 6
   output$wave_image6 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
-  
+
+
   # WAVE IMAGE 7
   output$wave_image7 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
-  
+
+
   # WAVE IMAGE 8
   output$wave_image8 <- renderImage({
     list(src = "images/WAVE.jpg",
          width= "225",
          height= "50")
   }, deleteFile = FALSE)
-  
-  
 
-  
-  
-  
+
+
+
+
+
 # Code to stop app when browser session window closes
 session$onSessionEnded(function() {
       stopApp()

--- a/app.R
+++ b/app.R
@@ -51,6 +51,10 @@ ipak(packages)
 
     tab_selected = "Wachusett"
 
+### Format Changes - ! to be moved to Update_Wave !
+
+  df_chem_quab <- df_chem_quab %>% rename(LocationDepth = Sampling_Level)
+
 ### Load Primary Modules
 
 source("modules1/home.R")
@@ -75,6 +79,7 @@ source("modules1/report_custom.R")
 # Inputs
 source("modules2/inputs/site_checkbox.R")
 source("modules2/inputs/station_level_checkbox.R")
+source("modules2/inputs/site_profile.R")
 source("modules2/inputs/param_select.R")
 source("modules2/inputs/param_checkbox.R")
 source("modules2/inputs/date_select.R")
@@ -156,17 +161,15 @@ tabPanel("Tributary",
   tabsetPanel(
     tabPanel("Quabbin",
              navlistPanel(widths = c(2, 10),
-                          tabPanel("Select / Filter data", FILTER_WQ_UI("mod_trib_quab_filter")),
-                          tabPanel("-- table", fluidRow(h5("Table to come"))
-                          ),
-                          tabPanel("-- plots",
+                          tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_trib_quab_filter")),
+                          tabPanel("-- Plots",
                                    tabsetPanel(
                                      tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_trib_quab_plot_time")),
                                      tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_trib_quab_plot_corr")),
                                      tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_trib_quab_plot_dist"))
                                    )
                           ),
-                          tabPanel("-- statistics",
+                          tabPanel("-- Statistics",
                                    tabsetPanel(
                                      tabPanel("Summary Statistics", STAT_TIME_WQ_UI("mod_trib_quab_stat_sum")),
                                      tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
@@ -179,22 +182,44 @@ tabPanel("Tributary",
     ),
     tabPanel("Ware",
              navlistPanel(widths = c(2, 10),
-                          tabPanel("SELECT / FILTER DATA", FILTER_WQ_UI("mod_trib_ware_filter")),
-                          tabPanel("- table", TIME_WQ_UI("mod_trib_ware_time")),
-                          tabPanel("- plots", CORRELATION_WQ_UI("mod_trib_ware_corr")),
-                          tabPanel("- statistics", DISTRIBUTION_WQ_UI("mod_trib_ware_dist")),
+                          tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_trib_ware_filter")),
+                          tabPanel("-- Plots",
+                                   tabsetPanel(
+                                     tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_trib_ware_plot_time")),
+                                     tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_trib_ware_plot_corr")),
+                                     tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_trib_ware_plot_dist"))
+                                   )
+                          ),
+                          tabPanel("-- Statistics",
+                                   tabsetPanel(
+                                     tabPanel("Summary Statistics", STAT_TIME_WQ_UI("mod_trib_ware_stat_sum")),
+                                     tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                     tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_trib_ware_stat_cormat"))
+                                   )
+                          ),
                           tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_ware_map", df = df_trib_ware)),
                           tabPanel("Metadata", fluidRow(h5("See Quabbin Tab. Can add data here in future")))
              ) # end navlist panel
     ),
     tabPanel("Wachusett",
              navlistPanel(widths = c(2, 10),
-                          tabPanel("SELECT / FILTER DATA", FILTER_WQ_UI("mod_trib_wach_filter")),
-                          tabPanel("- table", TIME_WQ_UI("mod_trib_wach_time")),
-                          tabPanel("- plots", CORRELATION_WQ_UI("mod_trib_wach_corr")),
-                          tabPanel("- statistics", DISTRIBUTION_WQ_UI("mod_trib_wach_dist")),
-                          tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_wach_map", df = df_trib_quab)),
-                          tabPanel("- MetaData", METADATA_UI("mod_trib_wach_meta"))
+                          tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_trib_wach_filter")),
+                          tabPanel("-- Plots",
+                                   tabsetPanel(
+                                     tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_trib_wach_plot_time")),
+                                     tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_trib_wach_plot_corr")),
+                                     tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_trib_wach_plot_dist"))
+                                   )
+                          ),
+                          tabPanel("-- Statistics",
+                                   tabsetPanel(
+                                     tabPanel("Summary Statistics", STAT_TIME_WQ_UI("mod_trib_wach_stat_sum")),
+                                     tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                     tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_trib_wach_stat_cormat"))
+                                   )
+                          ),
+                          tabPanel("Geospatial", MAP_PLOT_UI("mod_trib_wach_map", df = df_trib_wach)),
+                          tabPanel("MetaData", METADATA_UI("mod_trib_wach_meta"))
              ) # end navlist panel
     ),
     selected = tab_selected
@@ -213,127 +238,88 @@ tabPanel("Reservoir",
             column(2, imageOutput("wave_image4", height = 50), align = "center"),
             column(10, h2("Reservoir Water Quality Data", align = "center"))
    ),
-   navlistPanel(widths = c(2, 10),
-                "Bacteria",
-                tabPanel("SelectFilter Data",
-                         fluidRow(h4("Select and Filter Data", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Wachusett", FILTER_WQ_UI("mod_bact_wach_filter"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-                tabPanel("Time-Series",
-                         fluidRow(h4("Bacteria Time-Series Analysis", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Wachusett", TIME_WQ_UI("mod_bact_wach_time"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-                tabPanel("Correlation",
-                         fluidRow(h4("Bacteria Correlation Analysis", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Wachusett", CORRELATION_WQ_UI("mod_bact_wach_corr"))
-                         ) # end tabset panel
-                ), # end tabpanel
-                tabPanel("MetaData",
-                         fluidRow(h4("Tributary MetaData", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Wachusett", METADATA_UI("mod_bact_wach_meta"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-
-                "Chemical",
-                tabPanel("SelectFilter Data",
-                         fluidRow(h4("Select and Filter Data", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", FILTER_WQ_UI("mod_chem_quab_filter")),
-                           tabPanel("Wachusett", FILTER_WQ_UI("mod_chem_wach_filter"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-                tabPanel("Time-Series",
-                         fluidRow(h4("Chemical Time-Series Analysis", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", TIME_DEPTH_WQ_UI("mod_chem_quab_time")),
-                           tabPanel("Wachusett", TIME_DEPTH_WQ_UI("mod_chem_wach_time"))
-                         )
-                ),
-                tabPanel("Correlation",
-                         fluidRow(h4("Chemical Correlation Analysis", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", CORRELATION_DEPTH_WQ_UI("mod_chem_quab_corr")),
-                           tabPanel("Wachusett", CORRELATION_DEPTH_WQ_UI("mod_chem_wach_corr"))
-                         )
-                ),
-                tabPanel("Metadata",
-                         fluidRow(h4("Chemical Metadata", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", METADATA_UI("mod_chem_quab_meta")),
-                           tabPanel("Wachusett", METADATA_UI("mod_chem_wach_meta"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-
-                "Profile",
-                tabPanel("Heat Map",
-                         fluidRow(h4("Profile Heatmap", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", PROF_HEATMAP_UI("mod_prof_quab_heat", df_prof_quab)),
-                           tabPanel("Wachusett", PROF_HEATMAP_UI("mod_prof_wach_heat", df_prof_wach))
-                         )
-                ),
-                tabPanel("Line Plot",
-                         fluidRow(h4("Profile Line Plot", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", PROF_LINE_UI("mod_prof_quab_line", df_prof_quab)),
-                           tabPanel("Wachusett", PROF_LINE_UI("mod_prof_wach_line", df_prof_wach))
-                         )
-                ),
-                tabPanel("Table and Summary",
-                         fluidRow(h4("Profile Summary", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", PROF_TABLE_STAT_UI("mod_prof_quab_sum", df_prof_quab)),
-                           tabPanel("Wachusett", PROF_TABLE_STAT_UI("mod_prof_wach_sum", df_prof_wach))
-                         )
-                ),
-                tabPanel("Metadata",
-                         fluidRow(h4("Profile metadat", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Quabbin", METADATA_UI("mod_prof_quab_meta")),
-                           tabPanel("Wachusett", METADATA_UI("mod_prof_wach_meta"))
-                         ) # end tabset Panel
-                ), # end tabpanel
-
-
-                "Biological",
-                tabPanel("Phytoplankton",
-                         fluidRow(h4("Phytoplankton Plots and Data", align = "center")),
-                         tabsetPanel(
-                           tabPanel("Wachusett", PHYTO_UI("mod_phyto_wach_plots", df_phyto_wach))
-                         )
-                )
-
-   ) # end navlist
-
+   tabsetPanel(
+     tabPanel("Quabbin",
+              navlistPanel(widths = c(2, 10),
+                           "Chemical",
+                           tabPanel("Select / Filter data", FILTER_WQ_UI("mod_chem_quab_filter")),
+                           tabPanel("-- Plots",
+                                    tabsetPanel(
+                                      tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_chem_quab_plot_time")),
+                                      tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_chem_quab_plot_corr")),
+                                      tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_chem_quab_plot_dist"))
+                                    )
+                           ),
+                           tabPanel("-- Statistics",
+                                    tabsetPanel(
+                                      tabPanel("Summary Statistics", STAT_TIME_DEPTH_WQ_UI("mod_chem_quab_stat_sum")),
+                                      tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                      tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_chem_quab_stat_cormat"))
+                                    )
+                           ),
+                           tabPanel("Metadata", METADATA_UI("mod_chem_quab_meta")),
+                           "Profile",
+                           tabPanel("Heat Map", PROF_HEATMAP_UI("mod_prof_quab_heat", df_prof_wach)),
+                           tabPanel("Line Plot", PROF_LINE_UI("mod_prof_quab_line", df_prof_wach)),
+                           tabPanel("Table and Summary", PROF_TABLE_STAT_UI("mod_prof_quab_sum", df_prof_wach)),
+                           tabPanel("Metadata", METADATA_UI("mod_prof_quab_meta"))
+              ) # end navlist panel
+     ),
+     tabPanel("Wachusett",
+              navlistPanel(widths = c(2, 10),
+                           "Bacteria",
+                           tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_bact_wach_filter")),
+                           tabPanel("-- Plots",
+                                    tabsetPanel(
+                                      tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_bact_wach_plot_time")),
+                                      tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_bact_wach_plot_corr")),
+                                      tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_bact_wach_plot_dist"))
+                                    )
+                           ),
+                           tabPanel("-- Statistics",
+                                    tabsetPanel(
+                                      tabPanel("Summary Statistics", STAT_TIME_WQ_UI("mod_bact_wach_stat_sum")),
+                                      tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                      tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_bact_wach_stat_cormat"))
+                                    )
+                           ),
+                           tabPanel("Geospatial", MAP_PLOT_UI("mod_bact_wach_map", df = df_bact_wach)),
+                           tabPanel("Metadata", METADATA_UI("mod_bact_wach_meta")),
+                           "Chemical",
+                           tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_chem_wach_filter")),
+                           tabPanel("-- Plots",
+                                    tabsetPanel(
+                                      tabPanel("Time-Series Scatter", PLOT_TIME_WQ_UI("mod_chem_wach_plot_time")),
+                                      tabPanel("Correlation Scatter", PLOT_CORR_WQ_UI("mod_chem_wach_plot_corr")),
+                                      tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_chem_wach_plot_dist"))
+                                    )
+                           ),
+                           tabPanel("-- Statistics",
+                                    tabsetPanel(
+                                      tabPanel("Summary Statistics", STAT_TIME_DEPTH_WQ_UI("mod_chem_wach_stat_sum")),
+                                      tabPanel("Temporal Statistics", fluidRow(h5("Mann-Kendall Stats to come"))),
+                                      tabPanel("Correlation Matrix", PLOT_CORR_MATRIX_WQ_UI("mod_chem_wach_stat_cormat"))
+                                    )
+                           ),
+                           tabPanel("Metadata", METADATA_UI("mod_chem_wach_meta")),
+                           "Profile",
+                           tabPanel("Select / Filter Data", FILTER_WQ_UI("mod_prof_wach_filter")),
+                           tabPanel("-- Plots",
+                                    tabsetPanel(
+                                      tabPanel("Heat Map", PROF_HEATMAP_UI("mod_prof_wach_heat", df_prof_wach)),
+                                      tabPanel("Line Plot", PROF_LINE_UI("mod_prof_wach_line", df_prof_wach)),
+                                      tabPanel("Distribution Charts", DISTRIBUTION_WQ_UI("mod_prof_wach_plot_dist"))
+                                    )
+                           ),
+                           tabPanel("Table and Summary", PROF_TABLE_STAT_UI("mod_prof_wach_sum", df_prof_wach)),
+                           tabPanel("Metadata", METADATA_UI("mod_prof_wach_meta")),
+                           "Biological",
+                           tabPanel("Phytoplankton", PHYTO_UI("mod_phyto_wach_plots", df_phyto_wach))
+              ) # end navlist panel
+     ),
+     selected = tab_selected
+   )
  ),  # end Tabpanel (page)
-
-
-#######################################################
-# Map
-
-tabPanel("Map Plot",
-
-         # Title
-         fluidRow(
-                  column(2, imageOutput("wave_image5", height = 50), align = "center"),
-                  column(10, h2("Geospatial Plots", align = "center"))
-         ),
-         navlistPanel(widths = c(2, 10),
-                      "Reservoir Bacteria",
-                      tabPanel("Wachusett", MAP_PLOT_UI("mod_bact_wach_map", df = df_bact_wach)),
-                      "Reservoir Chemical",
-                      tabPanel("Quabbin", MAP_PLOT_UI("mod_chem_quab_map", df = df_chem_quab)),
-                      tabPanel("Wachusett", MAP_PLOT_UI("mod_chem_wach_map", df = df_chem_wach))
-         ) # end navlist
-
-), # end tabpanel (page)
-
 
 ###################################################################
 # Hydrology/Meteorology
@@ -444,9 +430,7 @@ server <- function(input, output, session) {
   ### Quabbin
 
   # Filter
-  Df_Trib_Quab <- callModule(FILTER_WQ, "mod_trib_quab_filter", df = df_trib_quab, df_site = df_trib_quab_site)
-
-  # Table
+  Df_Trib_Quab <- callModule(FILTER_WQ, "mod_trib_quab_filter", df = df_trib_quab, df_site = df_trib_quab_site, type = "wq")
 
   # Plots
   callModule(PLOT_TIME_WQ, "mod_trib_quab_plot_time", Df = Df_Trib_Quab$Long)
@@ -455,7 +439,7 @@ server <- function(input, output, session) {
 
   # Stats
   callModule(STAT_TIME_WQ, "mod_trib_quab_stat_sum", Df = Df_Trib_Quab$Long)  # Push in $Stats and get rid in module
-  #callModule(STAT_TIME_WQ, "mod_trib_quab_stat_temp", Df = Df_Trib_Quab)
+  # temp stats
   callModule(PLOT_CORR_MATRIX_WQ, "mod_trib_quab_stat_cormat", Df = Df_Trib_Quab$Wide)
 
   # Geospatial
@@ -466,95 +450,149 @@ server <- function(input, output, session) {
 
 
   ### Ware
+
+  # Filter
+  Df_Trib_Ware <- callModule(FILTER_WQ, "mod_trib_ware_filter", df = df_trib_ware, df_site = df_trib_ware_site, type = "wq")
+
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_trib_ware_plot_time", Df = Df_Trib_Ware$Long)
+  callModule(PLOT_CORR_WQ, "mod_trib_ware_plot_corr", Df = Df_Trib_Ware$Long)
+  callModule(DISTRIBUTION_WQ, "mod_trib_ware_plot_dist", Df = Df_Trib_Ware$Long)
+
+  # Stats
+  callModule(STAT_TIME_WQ, "mod_trib_ware_stat_sum", Df = Df_Trib_Ware$Long)  # Push in $Stats and get rid in module
+  # temp stats
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_trib_ware_stat_cormat", Df = Df_Trib_Ware$Wide)
+
+  # Geospatial
+  callModule(MAP_PLOT, "mod_trib_ware_map", df = df_trib_ware, df_site = df_trib_ware_site)
+
+
   ### Wachusett
 
-  # Select/Filter Data - Returns a list of 3 versions of reactive filtered dataframes (Long, Wide, Stat)
+  # Filter
+  Df_Trib_Wach <- callModule(FILTER_WQ, "mod_trib_wach_filter", df = df_trib_wach, df_site = df_trib_wach_site, type = "wq")
 
-  Df_Trib_Ware <- callModule(FILTER_WQ, "mod_trib_ware_filter", df = df_trib_ware, df_site = df_trib_ware_site)
-  Df_Trib_Wach <- callModule(FILTER_WQ, "mod_trib_wach_filter", df = df_trib_wach, df_site = df_trib_wach_site)
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_trib_wach_plot_time", Df = Df_Trib_Wach$Long)
+  callModule(PLOT_CORR_WQ, "mod_trib_wach_plot_corr", Df = Df_Trib_Wach$Long)
+  callModule(DISTRIBUTION_WQ, "mod_trib_wach_plot_dist", Df = Df_Trib_Wach$Long)
 
-  # Time Series
-  callModule(TIME_WQ, "mod_trib_ware_time", Df = Df_Trib_Ware$Long)
-  callModule(TIME_WQ, "mod_trib_wach_time", Df = Df_Trib_Wach$Long)
-  #callModule(time, "mod_trib_all_time", df = df_trib_all, df_site = df_trib_all_site)
+  # Stats
+  callModule(STAT_TIME_WQ, "mod_trib_wach_stat_sum", Df = Df_Trib_Wach$Long)  # Push in $Stats and get rid in module
+  # temp stats
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_trib_wach_stat_cormat", Df = Df_Trib_Wach$Wide)
 
-  # Correlation
-  callModule(CORRELATION_WQ, "mod_trib_ware_corr", Dfa = Df_Trib_Ware$Long, Dfb = Df_Trib_Ware$Wide)
-  callModule(CORRELATION_WQ, "mod_trib_wach_corr", Dfa = Df_Trib_Wach$Long, Dfb = Df_Trib_Wach$Wide)
-  #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
+  # Geospatial
+  callModule(MAP_PLOT, "mod_trib_wach_map", df = df_trib_wach, df_site = df_trib_wach_site)
 
-  # Distribution
-  callModule(DISTRIBUTION_WQ, "mod_trib_ware_dist", Df = Df_Trib_Ware$Stat)
-  callModule(DISTRIBUTION_WQ, "mod_trib_wach_dist", Df = Df_Trib_Wach$Stat)
-  #callModule(CORRELATION, "mod_trib_all_corr", df = df_trib_all, df_site = df_trib_all_site)
+  # MetaData
+  callModule(METADATA, "mod_trib_wach_meta", df = df_trib_wach, df_site = df_trib_wach_site, df_param = df_wach_param)
 
-  # Metadata
-  callModule(METADATA, "mod_trib_wach_meta", df = df_trib_wach, df_site = df_trib_wach_site, df_param = df_wq_wach_param)
+
 
 #############################################################
 # Reservoir
 
-  ### Bacteria
 
-  # Filter
-  Df_Bact_Wach <- callModule(FILTER_WQ, "mod_bact_wach_filter", df = df_bact_wach, df_site = df_bact_wach_site)
-
-  callModule(TIME_WQ, "mod_bact_wach_time", Df = Df_Bact_Wach$Long)
-
-  callModule(CORRELATION_WQ, "mod_bact_wach_corr", Dfa = Df_Bact_Wach$Long, Dfb = Df_Bact_Wach$Wide)
-
-  callModule(METADATA, "mod_bact_wach_meta", df_bact_wach, df_site = df_bact_wach_site, df_param = df_wq_wach_param)
+##### Quabbin #####
 
   ### Chemical
 
   # Filter
-  Df_Chem_Quab <- callModule(FILTER_WQ, "mod_chem_quab_filter", df = df_chem_quab, df_site = df_chem_quab_site, depth = TRUE)
-  Df_Chem_Wach <- callModule(FILTER_WQ, "mod_chem_wach_filter", df = df_chem_wach, df_site = df_chem_wach_site, depth = TRUE)
+  Df_Chem_Quab <- callModule(FILTER_WQ, "mod_chem_quab_filter", df = df_chem_quab, df_site = df_chem_quab_site, type = "wq_depth")
 
-  # Time-Series
-  callModule(TIME_DEPTH_WQ, "mod_chem_quab_time", Df = Df_Chem_Quab$Long)
-  callModule(TIME_DEPTH_WQ, "mod_chem_wach_time", Df = Df_Chem_Wach$Long)
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_chem_quab_plot_time", Df = Df_Chem_Quab$Long) # Update to Depth specific plot
+  callModule(PLOT_CORR_WQ, "mod_chem_quab_plot_corr", Df = Df_Chem_Quab$Long) # Update to Depth Specific Plot
+  callModule(DISTRIBUTION_WQ, "mod_chem_quab_plot_dist", Df = Df_Chem_Quab$Long) # Depth Specific?
 
-  # Correlation
-  callModule(CORRELATION_DEPTH_WQ, "mod_chem_quab_corr", df = df_chem_quab, df_site = df_chem_quab_site)
-  callModule(CORRELATION_DEPTH_WQ, "mod_chem_wach_corr", df = df_chem_wach, df_site = df_chem_wach_site)
+  # Stats
+  callModule(STAT_TIME_DEPTH_WQ, "mod_chem_quab_stat_sum", Df = Df_Chem_Quab$Long) # Push in $Stats and get rid in module
+  # temp stats
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_chem_quab_stat_cormat", Df = Df_Chem_Quab$Wide)
 
-  # Metadata
-  callModule(METADATA, "mod_chem_quab_meta",  df = df_chem_quab, df_site = df_chem_quab_site, df_param = df_quab_param)
-  callModule(METADATA, "mod_chem_wach_meta",  df = df_chem_wach, df_site = df_chem_wach_site)
+  # MetaData
+  callModule(METADATA, "mod_chem_quab_meta", df = df_chem_quab, df_site = df_chem_quab_site, df_param = df_chem_param)
 
-  ### Profile (physicochemical)
+  ### Profile
+
+  # Add a Filter Tab???????? - probably
+
+  # Heatmap
   callModule(PROF_HEATMAP, "mod_prof_quab_heat", df = df_prof_quab)
-  callModule(PROF_HEATMAP, "mod_prof_wach_heat", df = df_prof_wach)
 
+  # Line Plot
   callModule(PROF_LINE, "mod_prof_quab_line", df = df_prof_quab)
-  callModule(PROF_LINE, "mod_prof_wach_line", df = df_prof_wach)
-
+  # Table and Stats
   callModule(PROF_TABLE_STAT, "mod_prof_quab_sum", df = df_prof_quab)
-  callModule(PROF_TABLE_STAT, "mod_prof_wach_sum", df = df_prof_wach)
 
   # Change the Data Frames to Profile Data
   callModule(METADATA, "mod_prof_quab_meta", df = df_prof_quab, df_site = df_prof_quab_site, df_param = df_quab_param)
-  callModule(METADATA, "mod_prof_wach_meta", df = df_prof_wach, df_site = df_prof_wach_site)
 
-  # AquaBio
-  callModule(PHYTO, "mod_phyto_wach_plots", df = df_phyto_wach)
-  #callModule(phyto_summary, "mod_phyto_wach_plots", df = df_phyto_wach)
 
-####################################################################
-# Map Plot
 
-  # Trib
+##### Wachusett #####
 
-  callModule(MAP_PLOT, "mod_trib_ware_map", df = df_trib_ware, df_site = df_trib_ware_site)
-  callModule(MAP_PLOT, "mod_trib_wach_map", df = df_trib_wach, df_site = df_trib_wach_site)
+  ### Bacteria
 
-  # Bacteria
+  # Filter
+  Df_Bact_Wach <- callModule(FILTER_WQ, "mod_bact_wach_filter", df = df_bact_wach, df_site = df_bact_wach_site, type = "wq")
+
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_bact_wach_plot_time", Df = Df_Bact_Wach$Long)
+  callModule(PLOT_CORR_WQ, "mod_bact_wach_plot_corr", Df = Df_Bact_Wach$Long)
+  callModule(DISTRIBUTION_WQ, "mod_bact_wach_plot_dist", Df = Df_Bact_Wach$Long)
+
+  # Stats
+  callModule(STAT_TIME_WQ, "mod_bact_wach_stat_sum", Df = Df_Bact_Wach$Long)  # Push in $Stats and get rid in module
+  # temp stats
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_bact_wach_stat_cormat", Df = Df_Bact_Wach$Wide)
+
+  # Geospatial
   callModule(MAP_PLOT, "mod_bact_wach_map", df = df_bact_wach, df_site = df_bact_wach_site)
 
-  # Chemical
-  callModule(MAP_PLOT, "mod_chem_quab_map", df = df_chem_quab, df_site = df_chem_quab_site)
-  callModule(MAP_PLOT, "mod_chem_wach_map", df = df_chem_wach, df_site = df_chem_wach_site)
+  # MetaData
+  callModule(METADATA, "mod_bact_wach_meta", df = df_bact_wach, df_site = df_bact_wach_site, df_param = df_wach_param)
+
+  ### Chemical
+
+  # Filter
+  Df_Chem_Wach <- callModule(FILTER_WQ, "mod_chem_wach_filter", df = df_chem_wach, df_site = df_chem_wach_site, type = "wq_depth")
+
+  # Plots
+  callModule(PLOT_TIME_WQ, "mod_chem_wach_plot_time", Df = Df_Chem_Wach$Long) # Update to Depth specific plot
+  callModule(PLOT_CORR_WQ, "mod_chem_wach_plot_corr", Df = Df_Chem_Wach$Long) # Update to Depth Specific Plot
+  callModule(DISTRIBUTION_WQ, "mod_chem_wach_plot_dist", Df = Df_Chem_Wach$Long) # Depth Specific?
+
+  # Stats
+  callModule(STAT_TIME_DEPTH_WQ, "mod_chem_wach_stat_sum", Df = Df_Chem_Wach$Long) # Push in $Stats and get rid in module
+  # temp stats
+  callModule(PLOT_CORR_MATRIX_WQ, "mod_chem_wach_stat_cormat", Df = Df_Chem_Wach$Wide)
+
+  # MetaData
+  callModule(METADATA, "mod_chem_wach_meta", df = df_chem_wach, df_site = df_chem_wach_site, df_param = df_chem_param)
+
+  ### Profile
+
+  # Filter
+  Df_Prof_Wach <- callModule(FILTER_WQ, "mod_prof_wach_filter", df = df_prof_wach, df_site = df_prof_wach_site, type = "profile")
+
+  # Plots
+  callModule(PROF_HEATMAP, "mod_prof_wach_heat", df = df_prof_wach)
+  callModule(PROF_LINE, "mod_prof_wach_line", df = df_prof_wach)
+  callModule(DISTRIBUTION_WQ, "mod_prof_wach_plot_dist", Df = Df_Prof_Wach$Long) # Depth Specific?
+
+  # Table and Stats
+  callModule(PROF_TABLE_STAT, "mod_prof_wach_sum", df = df_prof_wach)
+
+  # Change the Data Frames to Profile Data
+  callModule(METADATA, "mod_prof_wach_meta", df = df_prof_wach, df_site = df_prof_wach_site, df_param = df_wach_param)
+
+  ### AquaBio
+
+  callModule(PHYTO, "mod_phyto_wach_plots", df = df_phyto_wach)
+
 
 ####################################################################
 # Hydrology/Meteorology/Statistics

--- a/functions/stat_functions.R
+++ b/functions/stat_functions.R
@@ -3,7 +3,7 @@
 getSeason <- function(input.date){
   numeric.date <- 100*month(input.date)+day(input.date)
   ## input Seasons upper limits in the form MMDD in the "break =" option:
-  cuts <- base::cut(numeric.date, breaks = c(0,319,0620,0921,1220,1231)) 
+  cuts <- base::cut(numeric.date, breaks = c(0,319,0620,0921,1220,1231))
   # rename the resulting groups (could've been done within cut(...levels=) if "Winter" wasn't double
   levels(cuts) <- c("Winter","Spring","Summer","Fall","Winter")
   return(cuts)
@@ -25,4 +25,14 @@ reorder_cormat <- function(cormat){
 get_upper_tri <- function(cormat){
   cormat[lower.tri(cormat)]<- NA
   return(cormat)
+}
+
+# REmove Outliers
+remove_outliers <- function(x, na.rm = TRUE, ...) {
+  qnt <- quantile(x, probs=c(.25, .75), na.rm = na.rm, ...)
+  H <- 1.5 * IQR(x, na.rm = na.rm)
+  y <- x
+  y[x < (qnt[1] - H)] <- NA
+  y[x > (qnt[2] + H)] <- NA
+  y
 }

--- a/modules1/correlation_wq.R
+++ b/modules1/correlation_wq.R
@@ -5,8 +5,8 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
-#   
+# Notes:
+#
 
 ##############################################################################################################################
 # User Interface
@@ -17,72 +17,38 @@ CORRELATION_WQ_UI <- function(id) {
 ns <- NS(id)
 
 tagList(
-  wellPanel(       
-    fluidRow(
-      column(3,
-             radioButtons(ns("df_choice"), "Full or Filtered Data:", 
-                          choices = c("full", "filtered"),
-                          inline = TRUE),
-             p(textOutput(ns("text_filtered"))),
-             wellPanel(
-               h4(textOutput(ns("text_site_null")), align = "center"),
-               h4(textOutput(ns("text_param_null")), align = "center"),
-               h4(textOutput(ns("text_date_null")), align = "center"),
-               h5(textOutput(ns("text_num_text")), align = "center"),
-               strong(textOutput(ns("text_num")), align = "center")
-             ), # end Well Panel
-             wellPanel(
-               SITE_MAP_UI(ns("site_map"))
-             ) # end Well Panel
-      ), # end Column
-      column(6,
-             SITE_CHECKBOX_UI(ns("site"))
-      ), # end Column
-      column(3,
-             PARAM_SELECT_UI(ns("param")),
-             br(),
-             DATE_SELECT_UI(ns("date"))
-      ) # end column
-    ) # end fluidrow     
-  ), # end well panel
-  
-  # Tabset panel for plots, tables, etc. 
+
+  # Tabset panel for plots, tables, etc.
   tabsetPanel(
-    
+
     # Plot Tab
     tabPanel("Scatter Plot",
-             h4(textOutput(ns("text_plot1_no_data"))),
-             h4(textOutput(ns("text_plot1_zero_data"))),
              PLOT_CORR_WQ_UI(ns("plot_scatter"))
     ), # end Tab Panel - Plot
-    
+
     # Summary Tabpanel
     tabPanel("Correlation Matrix",
-             h4(textOutput(ns("text_plot2_no_data"))),
-             h4(textOutput(ns("text_plot2_zero_data"))),
              PLOT_CORR_MATRIX_WQ_UI(ns("plot_matrix"))
-    ), # end Tab Panel - Summary
-    
+    )#, # end Tab Panel - Summary
+
     # Table Tabpanel
-    tabPanel("Table",
-             h4(textOutput(ns("text_table_no_data"))),
-             h4(textOutput(ns("text_table_zero_data"))),
-             fluidRow(br(),
-                      column(3,
-                             radioButtons(ns("table_format"), "Table Format",
-                                          choices = c("long", "wide")),
-                             downloadButton(ns("download_data"), "Download table as csv")
-                      ),
-                      column(9, 
-                             uiOutput(ns("column_ui"))
-                      ), 
-                      br()
-             ), # end Fluid Row
-             fluidRow(
-               dataTableOutput(ns("table"))
-             ) # end Fluid Row
-    ) # end Tab Panel - Table
-    
+    # tabPanel("Table",
+    #          fluidRow(br(),
+    #                   column(3,
+    #                          radioButtons(ns("table_format"), "Table Format",
+    #                                       choices = c("long", "wide")),
+    #                          downloadButton(ns("download_data"), "Download table as csv")
+    #                   ),
+    #                   column(9,
+    #                          uiOutput(ns("column_ui"))
+    #                   ),
+    #                   br()
+    #          ), # end Fluid Row
+    #          fluidRow(
+    #            dataTableOutput(ns("table"))
+    #          ) # end Fluid Row
+    # ) # end Tab Panel - Table
+
   ) # end tabsetpanel (plots, stats, etc.)
 ) # end taglist
 } # end UI function
@@ -92,194 +58,58 @@ tagList(
 # Server Function
 ##############################################################################################################################
 
-CORRELATION_WQ <- function(input, output, session, df_full, Df_Filtered, df_site) {
+CORRELATION_WQ <- function(input, output, session, Dfa, Dfb) {
 
-  
+
   ns <- session$ns # see General Note 1
-  
-  # Dataframe filtered or full based on Selection
-  Df1 <- reactive({
-    if(input$df_choice == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
-  
-  # Site Selection using Site Select Module
-  Site <- callModule(SITE_CHECKBOX, "site", Df = Df1)
-  
-  
-  # Reactive Dataframe - first filter of the dataframe for Site
-  Df2 <- reactive({
-    req(Site())
-    
-    Df1() %>% 
-      filter(LocationLabel %in% Site(),
-             !is.na(Result)) # can remove this once certain no NAs. Maybe remove for Rdata files
-  })
-  
-  
-  # Parameter Selection using ParameterSelect Module
-  Param <- callModule(PARAM_SELECT, "param", Df = Df2, Site = Site)
-  
-  
-  # Date Range Selection Using DateSelect Module
-  Date_Range <- callModule(DATE_SELECT, "date", Df = Df2, Site = Site)
-  
-  
-  
-  # Reactive Dataframe - filter for param, value range, date, and remove rows with NA for Result
-  Df3 <- reactive({
-    req(Param$Type(), Param$Range_Min(), Param$Range_Min(), Date_Range$Lower(), Date_Range$Upper()) # See General Note _
-    
-    Df2() %>% 
-      filter(Parameter %in% Param$Type(), 
-             Result > Param$Range_Min(), Result < Param$Range_Max(),
-             Date > Date_Range$Lower(), Date < Date_Range$Upper())
-  })
-  
-  # Reactive Dataframe - Wide Format (for Correlation Matrix and for option in table )
-  Df4 <- reactive({
-    Df3() %>%
-      select(-Units) %>%
-      distinct(LocationLabel, Date, Parameter, .keep_all = TRUE) %>%
-      spread("Parameter", "Result")
-  })
-  
-  
+
   # Plot - Scatter
-  callModule(PLOT_CORR_WQ, "plot_scatter", Df = Df3)
-  
+  callModule(PLOT_CORR_WQ, "plot_scatter", Df = Dfa)
+
   # Plot - Scatter
-  callModule(PLOT_CORR_MATRIX_WQ, "plot_matrix", Df = Df4)
-  
-  # Table
-  output$table <- renderDataTable(Df_Table())
-  
-  # Site Map
-  callModule(SITE_MAP, "site_map", df_site = df_site, Site_List = Site)
-  
-  
+  callModule(PLOT_CORR_MATRIX_WQ, "plot_matrix", Df = Dfb)
+
+
   ### Downloadable csv of selected dataset
-  
-  output$download_data <- downloadHandler(
-    filename = function() {
-      paste("DCRExportedWQData", ".csv", sep = "")
-    },
-    content = function(file) {
-      write_csv(Df_Table(), file)
-    }
-  )
-  
-  
-  # Column Selection for table output
-  output$column_ui <- renderUI({
-    if(input$table_format == "long"){
-      df <- Df3()
-    } else{
-      df <- Df4()
-    }
-    checkboxGroupInput(ns("column"), "Table Columns:", 
-                       choices = names(df), 
-                       selected = names(df),
-                       inline = TRUE)
-  })
-  
-  # Df for Table
-  Df_Table <- reactive({
-    req(input$column)
-    if(input$table_format == "long"){
-      Df3() %>% select(c(input$column))
-    } else{
-      Df4() %>% select(c(input$column))
-    }
-  })
-  
-  
-################ Texts ###################################
-  
-  # Text - Filtered Data
-  output$text_filtered <- renderText({
-    req(input$df_choice == "filtered") # See General Note 1
-    'This Dataset has been filtered and therefore some observations (data points) may be excluded.\n See "Filtered tab"'
-  })
-  
-  # Text - Select Site
-  output$text_site_null <- renderText({
-    req(!isTruthy(Site())) # See General Note 1
-    "Select Site(s)"
-  })
-  
-  # Text - Select Param
-  output$text_param_null <- renderText({
-    req(!isTruthy(Param$Type())) # See General Note 1
-    "Select Parameter"
-  })
-  
-  # Text - Select Param
-  output$text_date_null <- renderText({
-    req(!isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper())) # See General Note 1
-    "Select Lower Date Range"
-  })
-  
-  # Text - Number of Samples - Words
-  output$text_num_text <- renderText({
-    req(Df3()) # See General Note 1
-    "Number of Samples in Selected Data:"
-  })
-  
-  # Text - Number of Samples - Number
-  output$text_num <- renderText({
-    req(Df3()) # See General Note 1
-    Df3() %>% summarise(n()) %>% paste()
-  })
-  
-  # Text - Plot1- No data Selected
-  output$text_plot1_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Plot1 - Zero data Selected for Plot
-  output$text_plot1_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
-  # Text - Plot 2 - No data Selected
-  output$text_plot2_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Plot 2 - Zero Data Selected
-  output$text_plot2_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
-  # Text - Table - No data Selected
-  output$text_table_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Table - Zero data Selected
-  output$text_table_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
+#
+#   output$download_data <- downloadHandler(
+#     filename = function() {
+#       paste("DCRExportedWQData", ".csv", sep = "")
+#     },
+#     content = function(file) {
+#       write_csv(Df_Table(), file)
+#     }
+#   )
+#
+#
+#   # Column Selection for table output
+#   output$column_ui <- renderUI({
+#     if(input$table_format == "long"){
+#       df <- Dfa()
+#     } else{
+#       df <- Dfb()
+#     }
+#     checkboxGroupInput(ns("column"), "Table Columns:",
+#                        choices = names(df),
+#                        selected = names(df),
+#                        inline = TRUE)
+#   })
+#
+#   # Df for Table
+#   Df_Table <- reactive({
+#     req(input$column)
+#     if(input$table_format == "long"){
+#       Df3() %>% select(c(input$column))
+#     } else{
+#       Df4() %>% select(c(input$column))
+#     }
+#   })
 
 
-  
+
+
+
+
+
 } # end Server Function
 

--- a/modules1/distribution_wq.R
+++ b/modules1/distribution_wq.R
@@ -5,49 +5,22 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
-#   
+# Notes:
+#
 
 ##############################################################################################################################
 # User Interface
 ##############################################################################################################################
 
 DISTRIBUTION_WQ_UI <- function(id) {
-  
+
   ns <- NS(id)
-  
+
   tagList(
-    wellPanel(       
-      fluidRow(
-        column(3,
-               radioButtons(ns("df_choice"), "Full or Filtered Data:", 
-                            choices = c("full", "filtered"),
-                            inline = TRUE),
-               p(textOutput(ns("text_filtered"))),
-               wellPanel(
-                 h4(textOutput(ns("text_site_null")), align = "center"),
-                 h4(textOutput(ns("text_param_null")), align = "center"),
-                 h4(textOutput(ns("text_date_null")), align = "center"),
-                 h5(textOutput(ns("text_num_text")), align = "center"),
-                 strong(textOutput(ns("text_num")), align = "center")
-               ), # end Well Panel
-               wellPanel(
-                 SITE_MAP_UI(ns("site_map"))
-               ) # end Well Panel
-        ), # end Column
-        column(6,
-               SITE_CHECKBOX_UI(ns("site"))
-        ), # end Column
-        column(3,
-               PARAM_SELECT_UI(ns("param")),
-               br(),
-               DATE_SELECT_UI(ns("date"))
-        ) # end column
-      ) # end fluidrow     
-    ), # end well panel
-    
+
     sidebarLayout(
       sidebarPanel(
+        uiOutput(ns("param_ui")),
         radioButtons(ns("plot_type"), "Plot Type",
                      choices = c("Histogram", "Density Curve", "Box Plot"),
                      inline = TRUE),
@@ -57,16 +30,16 @@ DISTRIBUTION_WQ_UI <- function(id) {
           column(6,
                  radioButtons(ns("color"), "group by color",
                               choices = c("None" = "None",
-                                          "Site" = "LocationLabel", 
-                                          "Year", 
+                                          "Site" = "LocationLabel",
+                                          "Year",
                                           "Month",
                                           "Season"))
           ),
           column(6,
                  radioButtons(ns("facet"), "group by facet",
                               choices = c("None" = "None",
-                                          "Site" = "LocationLabel", 
-                                          "Year", 
+                                          "Site" = "LocationLabel",
+                                          "Year",
                                           "Month",
                                           "Season"))
                  )
@@ -88,90 +61,46 @@ DISTRIBUTION_WQ_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-DISTRIBUTION_WQ <- function(input, output, session, df_full, Df_Filtered, df_site) {
-  
-  # move to functions
-  remove_outliers <- function(x, na.rm = TRUE, ...) {
-    qnt <- quantile(x, probs=c(.25, .75), na.rm = na.rm, ...)
-    H <- 1.5 * IQR(x, na.rm = na.rm)
-    y <- x
-    y[x < (qnt[1] - H)] <- NA
-    y[x > (qnt[2] + H)] <- NA
-    y
-  }
-  
-  
-  
-  ns <- session$ns # see General Note 1
-  
-  # Dataframe filtered or full based on Selection
-  Df1 <- reactive({
-    if(input$df_choice == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
-  
-  # Site Selection using Site Select Module
-  Site <- callModule(SITE_CHECKBOX, "site", Df = Df1)
-  
-  
-  # Reactive Dataframe - first filter of the dataframe for Site
-  Df2 <- reactive({
-    req(Site())
-    
-    Df1() %>% 
-      filter(LocationLabel %in% Site(),
-             !is.na(Result)) # can remove this once certain no NAs. Maybe remove for Rdata files
-  })
-  
-  
-  # Parameter Selection using ParameterSelect Module
-  Param <- callModule(PARAM_SELECT, "param", Df = Df2, Site = Site, multiple = FALSE)
-  
-  
-  # Date Range Selection Using DateSelect Module
-  Date_Range <- callModule(DATE_SELECT, "date", Df = Df2, Site = Site)
-  
-  
-  
-  # Reactive Dataframe - filter for param, value range, date, and remove rows with NA for Result
-  Df3 <- reactive({
-    req(Param$Type(), Param$Range_Min(), Param$Range_Min(), Date_Range$Lower(), Date_Range$Upper()) # See General Note _
-    
-    df <- Df2() %>% 
-      filter(Parameter %in% Param$Type()[1], 
-             Result > Param$Range_Min(), Result < Param$Range_Max(),
-             Date > Date_Range$Lower(), Date < Date_Range$Upper()) %>%
-      mutate(Year = factor(lubridate::year(Date)), 
-             Season = getSeason(Date),
-             Month = month.abb[lubridate::month(Date)])
-    
-    if(input$rm_outliers == TRUE){
-      df %>% mutate(Result = remove_outliers(Result))
-    }else{
-      df
-    }
-  })
-  
-  
+DISTRIBUTION_WQ <- function(input, output, session, Df) {
 
-  
+  ns <- session$ns # see General Note 1
+
+  # Find Choices for Param
+  Param <- reactive({Df()$Parameter %>% factor() %>% levels()})
+
+  # Parameter Choice
+  output$param_ui <- renderUI({
+    if(Df() %>% summarise(n()) %>% unlist() != 0){
+      radioButtons(ns("param"), "Parameter",
+                   choices = Param())
+    }
+  })
+
+  # Remove Outliers - see function in functions/stat_functions.R
+  Df1 <- reactive({
+
+    df_temp <- Df() %>% filter(Parameter == input$param)
+
+    if(input$rm_outliers == TRUE){
+      df_temp %>% mutate(Result = remove_outliers(Result))
+    }else{
+      df_temp
+    }
+  })
+
+
   # render UI
   output$histo_ui <- renderUI({
-    
+
     if(input$plot_type == "Histogram"){
-    # min(Df3()$Result, na.rm = TRUE):max(Df3()$Result, na.rm = TRUE)
-    slide_vec <- pretty(Df3()$Result, n = 20)
+    slide_vec <- pretty(Df1()$Result, n = 20)
     interval <- (max(slide_vec) - min(slide_vec)) / (length(slide_vec)-1)
     digit <- round(log10(interval))*-1 + 2
     slide_val <- round(interval, digit)*2
     slide_min_step <- slide_val/4
     slide_max <- slide_val*2
-    
-    
+
+
     tagList(
       hr(),
       sliderInput(ns("bin_size"), "Bin Size (Hstogram)",
@@ -182,12 +111,12 @@ DISTRIBUTION_WQ <- function(input, output, session, df_full, Df_Filtered, df_sit
                    inline = TRUE)
     )
     } else{
-      
+
     }
-    
+
   })
-  
-  
+
+
   # Plot Output
   output$plot <- renderPlot({
     P()
@@ -195,9 +124,9 @@ DISTRIBUTION_WQ <- function(input, output, session, df_full, Df_Filtered, df_sit
 
   # Plot
   P <- reactive({
-    
-    p <- ggplot(Df3())
-    
+
+    p <- ggplot(Df1())
+
     # Histogram
     if(input$plot_type == "Histogram"){
       if(input$color == "None"){
@@ -210,109 +139,56 @@ DISTRIBUTION_WQ <- function(input, output, session, df_full, Df_Filtered, df_sit
           p <-  p + geom_histogram(aes_string(x = "Result", fill = input$color, color = input$color),
                                    alpha = 0.1, size =1.0,  binwidth = input$bin_size, position = input$position)
         }
-        
+
       }
     # Density Curve
     } else if(input$plot_type == "Density Curve"){
       if(input$color == "None"){
         p <-  p + geom_density(aes(x = Result), size = 1.0)
       } else{
-        p <-  p + geom_density(aes_string(x = "Result", color = input$color), 
+        p <-  p + geom_density(aes_string(x = "Result", color = input$color),
                                alpha = 0.1, size =1.0)
       }
     # Box Plot
     } else if(input$plot_type == "Box Plot"){
       if(input$color == "None"){
-        p <-   p + geom_boxplot(aes(x = Parameter, y = Result), 
+        p <-   p + geom_boxplot(aes(x = Parameter, y = Result),
                                 alpha = 0.5, size =1.0, width = 0.8, position = position_dodge(1)) +
           coord_flip()
       } else{
-        p <- p + geom_boxplot(aes_string(x = "Parameter", y = "Result", fill = input$color, color = input$color), 
-                              alpha = 0.5, size =1.0, width = 0.8, position = position_dodge(1)) + 
+        p <- p + geom_boxplot(aes_string(x = "Parameter", y = "Result", fill = input$color, color = input$color),
+                              alpha = 0.5, size =1.0, width = 0.8, position = position_dodge(1)) +
           coord_flip()
       }
     }
-    
+
     # Facet Wrap
     if(input$facet != "None"){
       p <- p + facet_wrap(as.formula(paste("~", input$facet)))
     }
-    
-    p <- p + xlab(paste(Param$Type(), " (", Text_Units_X(),")", sep= ""))
-    
+
+    p <- p + xlab(paste(input$param, " (", Text_Units_X(),")", sep= ""))
+
     p
-    
+
   })
-  
-  
-  Text_Units_X <- reactive({Df3() %>% filter(Parameter == Param$Type()) %>% .$Units %>% unique() %>% paste(collapse = ", ")})
-  
-  
-  # Site Map
-  callModule(SITE_MAP, "site_map", df_site = df_site, Site_List = Site)
-  
-  
- 
+
+
+  Text_Units_X <- reactive({Df1() %>% filter(Parameter == input$param) %>% .$Units %>% unique() %>% paste(collapse = ", ")})
+
+
+
   ################ Texts ###################################
-  
-  # Text - Filtered Data
-  output$text_filtered <- renderText({
-    req(input$df_choice == "filtered") # See General Note 1
-    'This Dataset has been filtered and therefore some observations (data points) may be excluded.\n See "Filtered tab"'
-  })
-  
-  # Text - Select Site
-  output$text_site_null <- renderText({
-    req(!isTruthy(Site())) # See General Note 1
-    "Select Site(s)"
-  })
-  
-  # Text - Select Param
-  output$text_param_null <- renderText({
-    req(!isTruthy(Param$Type())) # See General Note 1
-    "Select Parameter"
-  })
-  
-  # Text - Select Param
-  output$text_date_null <- renderText({
-    req(!isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper())) # See General Note 1
-    "Select Lower Date Range"
-  })
-  
-  # Text - Number of Samples - Words
-  output$text_num_text <- renderText({
-    req(Df3()) # See General Note 1
-    "Number of Samples in Selected Data:"
-  })
-  
-  # Text - Number of Samples - Number
-  output$text_num <- renderText({
-    req(Df3()) # See General Note 1
-    Df3() %>% summarise(n()) %>% paste()
-  })
-  
-  # Text - Plot- No data Selected
-  output$text_plot_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Plot - Zero data Selected for Plot
-  output$text_plot_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
+
+
   # Text - Plot - Zero data Selected for Plot
   output$text_box_plot <- renderText({
     req(input$plot_type == "Box Plot") # See General Note 1
     "Caution should be taken when there is a small number of observations represented by a box plot"
   })
-  
-  
-  
+
+
+
 } # end Server Function
 
 

--- a/modules1/filter_wq.R
+++ b/modules1/filter_wq.R
@@ -21,112 +21,128 @@ FILTER_WQ_UI <- function(id) {
   ns <- NS(id) # see General Note 1
 
   tagList(
-    fluidRow(h4("Select and Filter Data", align = "center")),
     wellPanel(
-      fluidRow(h3("Select Data")),
       fluidRow(
-        column(3,
+        column(2,
+               downloadButton(ns("download_data"), "Download table as csv")
+        ),
+        column(10,
+               checkboxInput(ns("wide"), 'transform to "wide" data format (Caution should be taken)')
+        )
+      )
+    ),
+    tabsetPanel(
+      tabPanel("Select / Filter Data",
                wellPanel(
-                 h4(textOutput(ns("text_site_null")), align = "center"),
-                 h4(textOutput(ns("text_param_null")), align = "center"),
-                 h4(textOutput(ns("text_date_null")), align = "center"),
-                 h5(textOutput(ns("text_num_text")), align = "center"),
-                 strong(textOutput(ns("text_num")), align = "center")
-               ), # end Well Panel
+                 fluidRow(h3("Main Selections", align = "center")),
+                 fluidRow(
+                   column(3,
+                          wellPanel(
+                            h4(textOutput(ns("text_site_null")), align = "center"),
+                            h4(textOutput(ns("text_param_null")), align = "center"),
+                            h4(textOutput(ns("text_date_null")), align = "center"),
+                            h5(textOutput(ns("text_num_text")), align = "center"),
+                            strong(textOutput(ns("text_num")), align = "center")
+                          ), # end Well Panel
+                          wellPanel(
+                            SITE_MAP_UI(ns("site_map"))
+                          ) # end Well Panel
+                   ), # end Column
+                   column(6,
+                          uiOutput(ns("site_ui"))
+                   ), # end Column
+                   column(3,
+                          PARAM_SELECT_UI(ns("param")),
+                          br(),
+                          DATE_SELECT_UI(ns("date"))
+                   ) # end column
+                 ) # end fluidrow
+               ), # end well panel
+               # Advanced Filters
                wellPanel(
-                 SITE_MAP_UI(ns("site_map"))
-               ) # end Well Panel
-        ), # end Column
-        column(6,
-               uiOutput(ns("site_ui"))
-        ), # end Column
-        column(3,
-               PARAM_SELECT_UI(ns("param")),
-               br(),
-               DATE_SELECT_UI(ns("date"))
-        ) # end column
-      ) # end fluidrow
-    ), # end well panel
-    # Advanced Filters
-    wellPanel(
-      fluidRow(h3("Advanced Filters")),
-      fluidRow(
-        column(4,
-               # Date Selection
-               wellPanel(
-                 # Month
-                 CHECKBOX_SELECT_ALL_UI(ns("month"))
-               ), # end Well Panel
-               wellPanel(
-                 # Year
-                 SELECT_SELECT_ALL_UI(ns("year"))
-               ) # end Well Panel
-        ), # end Column
-        column(4,
-               # # Flag Selection
-               # wellPanel(
-               #   SELECT_SELECT_ALL_UI(ns("flag"))
-               # ), # end Well Panel
-               # storm Sample Selection
-               # wellPanel(
-               #   CHECKBOX_SELECT_ALL_UI(ns("storm"))
-               # ), # end Well Panel
-               # Text - Number of Samples or "Select a site"
-               wellPanel(
-                 h5(textOutput(ns("text_no_month"))),
-                 h5(textOutput(ns("text_no_year"))),
-                 h5(textOutput(ns("text_no_flag"))),
-                 h5(textOutput(ns("text_no_storm")))
-               ) # end Well Panel
-        ), # end column
-        column(4,
-               # Meteoro/Hydro Filter 1
-               wellPanel(
-                 strong("Meteoro/Hydro Filter 1"), # Bold Text
-                 br(), br(),
-                 radioButtons(ns("met_option_1"), label = NULL,
-                              choices = c("off", "on", "group"),
-                              inline = TRUE),
-                 selectInput(ns("met_param_1"), label = NULL,
-                             choices = c("Wind Speed",
-                                         "Wind Direction",
-                                         "Precipitation - 24 hrs",
-                                         "Precipitation - 48 hrs",
-                                         "Temperature",
-                                         "Cloud Cover",
-                                         "Flow - Quabbin Aquaduct",
-                                         "Flow - East Branch Swift",
-                                         "Flow - West Branch Swift",
-                                         "Flow - Quinapoxet",
-                                         "Flow - Stillwater"),
-                             selected = "Wind Speed"),
-                 sliderInput(ns("met_value_1"), "Value Range:", min = 0, max = 12, value = c(0,12), step = 0.5)
-               ), # end Well Panel
-               # Meteoro/Hydro Filter 2
-               wellPanel(
-                 strong("Meteoro/Hydro Filter 2"), # Bold Text
-                 br(), br(),
-                 radioButtons(ns("met_option_2"), label = NULL,
-                              choices = c("off", "on", "group"),
-                              inline = TRUE),
-                 selectInput(ns("met_param_2"), label = NULL,
-                             choices = c("Wind Speed",
-                                         "Wind Direction",
-                                         "Precipitation - 24 hrs",
-                                         "Precipitation - 48 hrs",
-                                         "Temperature",
-                                         "Cloud Cover",
-                                         "Flow - Quabbin Aquaduct",
-                                         "Flow - East Branch Swift",
-                                         "Flow - West Branch Swift",
-                                         "Flow - Quinapoxet",
-                                         "Flow - Stillwater"),
-                             selected = "Precipitation - 24 hrs"),
-                 sliderInput(ns("met_value_2"), "Value Range:", min = 0, max = 12, value = c(0,12), step = 0.5)
-               ) # end Well Panel
-        ) # end column
-      ) # end fluidrow
-    ) # end well panel
+                 fluidRow(h3("Advanced Filters")),
+                 fluidRow(
+                   column(4,
+                          # Date Selection
+                          wellPanel(
+                            # Month
+                            CHECKBOX_SELECT_ALL_UI(ns("month"))
+                          ), # end Well Panel
+                          wellPanel(
+                            # Year
+                            SELECT_SELECT_ALL_UI(ns("year"))
+                          ) # end Well Panel
+                   ), # end Column
+                   column(4,
+                          # # Flag Selection
+                          # wellPanel(
+                          #   SELECT_SELECT_ALL_UI(ns("flag"))
+                          # ), # end Well Panel
+                          # storm Sample Selection
+                          # wellPanel(
+                          #   CHECKBOX_SELECT_ALL_UI(ns("storm"))
+                          # ), # end Well Panel
+                          # Text - Number of Samples or "Select a site"
+                          wellPanel(
+                            h5(textOutput(ns("text_no_month"))),
+                            h5(textOutput(ns("text_no_year"))),
+                            h5(textOutput(ns("text_no_flag"))),
+                            h5(textOutput(ns("text_no_storm")))
+                          ) # end Well Panel
+                   ), # end column
+                   column(4,
+                          # Meteoro/Hydro Filter 1
+                          wellPanel(
+                            strong("Meteoro/Hydro Filter 1"), # Bold Text
+                            br(), br(),
+                            radioButtons(ns("met_option_1"), label = NULL,
+                                         choices = c("off", "on", "group"),
+                                         inline = TRUE),
+                            selectInput(ns("met_param_1"), label = NULL,
+                                        choices = c("Wind Speed",
+                                                    "Wind Direction",
+                                                    "Precipitation - 24 hrs",
+                                                    "Precipitation - 48 hrs",
+                                                    "Temperature",
+                                                    "Cloud Cover",
+                                                    "Flow - Quabbin Aquaduct",
+                                                    "Flow - East Branch Swift",
+                                                    "Flow - West Branch Swift",
+                                                    "Flow - Quinapoxet",
+                                                    "Flow - Stillwater"),
+                                        selected = "Wind Speed"),
+                            sliderInput(ns("met_value_1"), "Value Range:", min = 0, max = 12, value = c(0,12), step = 0.5)
+                          ), # end Well Panel
+                          # Meteoro/Hydro Filter 2
+                          wellPanel(
+                            strong("Meteoro/Hydro Filter 2"), # Bold Text
+                            br(), br(),
+                            radioButtons(ns("met_option_2"), label = NULL,
+                                         choices = c("off", "on", "group"),
+                                         inline = TRUE),
+                            selectInput(ns("met_param_2"), label = NULL,
+                                        choices = c("Wind Speed",
+                                                    "Wind Direction",
+                                                    "Precipitation - 24 hrs",
+                                                    "Precipitation - 48 hrs",
+                                                    "Temperature",
+                                                    "Cloud Cover",
+                                                    "Flow - Quabbin Aquaduct",
+                                                    "Flow - East Branch Swift",
+                                                    "Flow - West Branch Swift",
+                                                    "Flow - Quinapoxet",
+                                                    "Flow - Stillwater"),
+                                        selected = "Precipitation - 24 hrs"),
+                            sliderInput(ns("met_value_2"), "Value Range:", min = 0, max = 12, value = c(0,12), step = 0.5)
+                          ) # end Well Panel
+                   ) # end column
+                 ) # end fluidrow
+               ) # end well panel
+      ),
+      tabPanel("View Data in Table",
+               dataTableOutput(ns("table"))
+      )
+    )
   ) # end taglist
 } # end UI function
 
@@ -138,8 +154,8 @@ FILTER_WQ_UI <- function(id) {
 # This module does not take any reactive expressions. Changes will have to be made to accmodate reactive expressions
 # dfs is a list of dataframes
 
-FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
-
+FILTER_WQ <- function(input, output, session, df, df_site, type = "wq") {
+# Types include: "wq", "wq_depth", and "profile". More can be added
 ########################################################
 # Main Selection
 
@@ -149,18 +165,22 @@ FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
 
   # Display sites w/o depths OR sites w/ Depths
   output$site_ui <- renderUI({
-    if(depth == FALSE){
+    if(type == "wq"){
       SITE_CHECKBOX_UI(ns("site"))
-    } else {
+    } else if(type == "wq_depth"){
       STATION_LEVEL_CHECKBOX_UI(ns("site"))
+    } else if(type == "profile"){
+      SITE_PROFILE_UI(ns("site"))
     }
   })
 
   # Site Selection using Site Select Module
-  Site <- if(depth == FALSE){
+  Site <- if(type == "wq"){
     callModule(SITE_CHECKBOX, "site", Df = reactive({df}))
-  } else {
+  } else if(type == "wq_depth"){
     callModule(STATION_LEVEL_CHECKBOX, "site", Df = reactive({df}))
+  } else if(type == "profile"){
+    callModule(SITE_PROFILE, "site", Df = reactive({df}))
   }
 
   # Site Map
@@ -171,19 +191,27 @@ FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
   Df1 <- reactive({
     req(Site())
 
+    if(type == "wq" | type == "wq_depth"){
     df %>%
       filter(LocationLabel %in% Site(),
-             !is.na(Result)) # can remove this once certain no NAs. Maybe remove for Rdata files
+             !is.na(Result)) # Is this needed? can remove this once certain no NAs.
+    } else if(type == "profile"){
+      df %>%
+        filter(LocationLabel %in% Site()$Site,
+               # Depthm >= Site()$Depth_Lower,
+               # Depthm >= Site()$Depth_Upper,
+               !is.na(Result)) # Is this needed? can remove this once certain no NAs.
+    }
   })
 
 
   ### Parameter and Date Range
 
   # Parameter Selection using ParameterSelect Module
-  Param <- callModule(PARAM_SELECT, "param", Df = Df1, Site = Site)
+  Param <- callModule(PARAM_SELECT, "param", Df = Df1)
 
   # Date Range Selection Using DateSelect Module
-  Date_Range <- callModule(DATE_SELECT, "date", Df = Df1, Site = Site)
+  Date_Range <- callModule(DATE_SELECT, "date", Df = Df1)
 
   # Reactive Dataframe - filter for param, value range, date, and remove rows with NA for Result
   Df2 <- reactive({
@@ -329,6 +357,8 @@ FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
 
   # Reactive Dataframe - Wide Format (for Correlation ScatterPlot and Correlation Matrix)
   Df3_Wide <- reactive({
+    # require Dataframe to be more than zero observations - prvent from crashing
+    req(Df3() %>% summarise(n()) %>% unlist() != 0)
     Df3() %>%
       select(-Units) %>%
       distinct(LocationLabel, Date, Parameter, .keep_all = TRUE) %>%
@@ -344,15 +374,37 @@ FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
   })
 
 
+#####################################################
+# CSV output and Table
+
+  # Dataframe for output and Table
+  Df_Table <- reactive({
+    if(input$wide){
+      Df3_Wide()
+    } else{
+      Df3()
+    }
+  })
+
+  # render Datatable
+  output$table <- renderDataTable(Df_Table(), selection = 'none')
+
+  # Downloadable csv of selected dataset
+  output$download_data <- downloadHandler(
+    filename = function() {
+      paste("DCRExportedWQData", ".csv", sep = "")
+    },
+    content = function(file) {
+      write_csv(Df_Table(), file)
+    }
+  )
+
+#####################################################
+# Return from Module a list of reactive dataframes.
 
   return(list(Long = Df3,
               Wide = Df3_Wide,
               Stat = Df3_Stat))
-
-  # return(list(Long = reactive({Df3()}),
-  #             Wide = reactive({Df3_Wide()}),
-  #             Stat = reactive({Df3_Stat()})))
-
 
 } # end Server Function
 

--- a/modules1/filter_wq.R
+++ b/modules1/filter_wq.R
@@ -5,7 +5,7 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
+# Notes:
 #   1. req() will delay the rendering of a widget or other reactive object until a certain logical expression is TRUE or not NULL
 #
 # To-Do List:
@@ -17,23 +17,42 @@
 ##############################################################################################################################
 
 FILTER_WQ_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
+    fluidRow(h4("Select and Filter Data", align = "center")),
     wellPanel(
+      fluidRow(h3("Select Data")),
+      fluidRow(
+        column(3,
+               wellPanel(
+                 h4(textOutput(ns("text_site_null")), align = "center"),
+                 h4(textOutput(ns("text_param_null")), align = "center"),
+                 h4(textOutput(ns("text_date_null")), align = "center"),
+                 h5(textOutput(ns("text_num_text")), align = "center"),
+                 strong(textOutput(ns("text_num")), align = "center")
+               ), # end Well Panel
+               wellPanel(
+                 SITE_MAP_UI(ns("site_map"))
+               ) # end Well Panel
+        ), # end Column
+        column(6,
+               uiOutput(ns("site_ui"))
+        ), # end Column
+        column(3,
+               PARAM_SELECT_UI(ns("param")),
+               br(),
+               DATE_SELECT_UI(ns("date"))
+        ) # end column
+      ) # end fluidrow
+    ), # end well panel
+    # Advanced Filters
+    wellPanel(
+      fluidRow(h3("Advanced Filters")),
       fluidRow(
         column(4,
                # Date Selection
-               wellPanel(
-                 # Date Range
-                 dateRangeInput(ns("date"), "Date Range:", 
-                                start = as.Date("2010-1-1"), 
-                                end = Sys.Date(),  
-                                min = as.Date("1990-1-1"),
-                                max = Sys.Date(),
-                                startview = "year")
-               ), # end Well Panel
                wellPanel(
                  # Month
                  CHECKBOX_SELECT_ALL_UI(ns("month"))
@@ -44,14 +63,14 @@ FILTER_WQ_UI <- function(id) {
                ) # end Well Panel
         ), # end Column
         column(4,
-               # Flag Selection
-               wellPanel(
-                 SELECT_SELECT_ALL_UI(ns("flag"))
-               ), # end Well Panel
+               # # Flag Selection
+               # wellPanel(
+               #   SELECT_SELECT_ALL_UI(ns("flag"))
+               # ), # end Well Panel
                # storm Sample Selection
-               wellPanel(
-                 CHECKBOX_SELECT_ALL_UI(ns("storm"))
-               ), # end Well Panel
+               # wellPanel(
+               #   CHECKBOX_SELECT_ALL_UI(ns("storm"))
+               # ), # end Well Panel
                # Text - Number of Samples or "Select a site"
                wellPanel(
                  h5(textOutput(ns("text_no_month"))),
@@ -65,12 +84,12 @@ FILTER_WQ_UI <- function(id) {
                wellPanel(
                  strong("Meteoro/Hydro Filter 1"), # Bold Text
                  br(), br(),
-                 radioButtons(ns("met_option_1"), label = NULL, 
-                              choices = c("off", "on", "group"), 
+                 radioButtons(ns("met_option_1"), label = NULL,
+                              choices = c("off", "on", "group"),
                               inline = TRUE),
-                 selectInput(ns("met_param_1"), label = NULL, 
-                             choices = c("Wind Speed", 
-                                         "Wind Direction", 
+                 selectInput(ns("met_param_1"), label = NULL,
+                             choices = c("Wind Speed",
+                                         "Wind Direction",
                                          "Precipitation - 24 hrs",
                                          "Precipitation - 48 hrs",
                                          "Temperature",
@@ -87,12 +106,12 @@ FILTER_WQ_UI <- function(id) {
                wellPanel(
                  strong("Meteoro/Hydro Filter 2"), # Bold Text
                  br(), br(),
-                 radioButtons(ns("met_option_2"), label = NULL, 
-                              choices = c("off", "on", "group"), 
+                 radioButtons(ns("met_option_2"), label = NULL,
+                              choices = c("off", "on", "group"),
                               inline = TRUE),
-                 selectInput(ns("met_param_2"), label = NULL, 
-                             choices = c("Wind Speed", 
-                                         "Wind Direction", 
+                 selectInput(ns("met_param_2"), label = NULL,
+                             choices = c("Wind Speed",
+                                         "Wind Direction",
                                          "Precipitation - 24 hrs",
                                          "Precipitation - 48 hrs",
                                          "Temperature",
@@ -106,7 +125,7 @@ FILTER_WQ_UI <- function(id) {
                  sliderInput(ns("met_value_2"), "Value Range:", min = 0, max = 12, value = c(0,12), step = 0.5)
                ) # end Well Panel
         ) # end column
-      ) # end fluidrow     
+      ) # end fluidrow
     ) # end well panel
   ) # end taglist
 } # end UI function
@@ -119,106 +138,221 @@ FILTER_WQ_UI <- function(id) {
 # This module does not take any reactive expressions. Changes will have to be made to accmodate reactive expressions
 # dfs is a list of dataframes
 
-FILTER_WQ <- function(input, output, session, dfs, col) { 
+FILTER_WQ <- function(input, output, session, df, df_site, depth = FALSE) {
+
+########################################################
+# Main Selection
+
+  ns <- session$ns # see General Note 1
+
+  ### Site Selection
+
+  # Display sites w/o depths OR sites w/ Depths
+  output$site_ui <- renderUI({
+    if(depth == FALSE){
+      SITE_CHECKBOX_UI(ns("site"))
+    } else {
+      STATION_LEVEL_CHECKBOX_UI(ns("site"))
+    }
+  })
+
+  # Site Selection using Site Select Module
+  Site <- if(depth == FALSE){
+    callModule(SITE_CHECKBOX, "site", Df = reactive({df}))
+  } else {
+    callModule(STATION_LEVEL_CHECKBOX, "site", Df = reactive({df}))
+  }
+
+  # Site Map
+  callModule(SITE_MAP, "site_map", df_site = df_site, Site_List = Site)
+
+
+  # Reactive Dataframe - first filter of the dataframe for Site
+  Df1 <- reactive({
+    req(Site())
+
+    df %>%
+      filter(LocationLabel %in% Site(),
+             !is.na(Result)) # can remove this once certain no NAs. Maybe remove for Rdata files
+  })
+
+
+  ### Parameter and Date Range
+
+  # Parameter Selection using ParameterSelect Module
+  Param <- callModule(PARAM_SELECT, "param", Df = Df1, Site = Site)
+
+  # Date Range Selection Using DateSelect Module
+  Date_Range <- callModule(DATE_SELECT, "date", Df = Df1, Site = Site)
+
+  # Reactive Dataframe - filter for param, value range, date, and remove rows with NA for Result
+  Df2 <- reactive({
+    req(Param$Type(), Param$Range_Min(), Param$Range_Min(), Date_Range$Lower(), Date_Range$Upper()) # See General Note _
+
+    Df1() %>%
+      filter(Parameter %in% Param$Type(),
+             Result > Param$Range_Min(), Result < Param$Range_Max(),
+             Date > Date_Range$Lower(), Date < Date_Range$Upper())
+  })
+
+
+  ### Texts
+
+  # Text - Select Site
+  output$text_site_null <- renderText({
+    req(!isTruthy(Site())) # See General Note 1
+    "Select Site(s)"
+  })
+
+  # Text - Select Param
+  output$text_param_null <- renderText({
+    req(!isTruthy(Param$Type())) # See General Note 1
+    "Select Parameter"
+  })
+
+  # Text - Select Param
+  output$text_date_null <- renderText({
+    req(!isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper())) # See General Note 1
+    "Select Lower Date Range"
+  })
+
+  # Text - Number of Samples - Words
+  output$text_num_text <- renderText({
+    req(Df3()) # See General Note 1
+    "Number of Samples in Selected Data:"
+  })
+
+  # Text - Number of Samples - Number
+  output$text_num <- renderText({
+    req(Df3()) # See General Note 1
+    Df3() %>% summarise(n()) %>% paste()
+  })
+
+
+
+
+
+##################################################
+# Advanced Filter
 
   ### Month Selection
-  
+
   # server
   Month <- callModule(CHECKBOX_SELECT_ALL, "month",
                             label = "Months:",
-                            choices = reactive({month.name}), 
-                            selected = reactive({month.name}), 
+                            choices = reactive({month.name}),
+                            selected = reactive({month.name}),
                             colwidth = 3,
-                            hidden = TRUE,
                             inline = TRUE)
-  
-  
+
+
   ### Year Selection
-  
+
   # Choices
   year_choices <- c(rev(year(seq(as.Date("1980-01-01"), Sys.Date(), "years")))) # Change to first year of data
-  
-  # Server
-  Year <- callModule(SELECT_SELECT_ALL, "year", 
-                           label = "Years:", 
-                           choices = reactive({year_choices}), 
-                           selected = reactive({year_choices}), 
-                           colwidth = 3,
-                           hidden = TRUE)
-  
-  
-  ### Flag Selection
-
-  # Choices
-  flag_choices <- dfs[[1]]$FlagCode %>% factor() %>% levels()
 
   # Server
-  Flag <- callModule(SELECT_SELECT_ALL, "flag",
-                     label = "Flags:",
-                     choices = reactive({flag_choices}),
-                     selected = reactive({flag_choices}),
-                     colwidth = 3,
-                     hidden = TRUE)
+  Year <- callModule(SELECT_SELECT_ALL, "year",
+                           label = "Years:",
+                           choices = reactive({year_choices}),
+                           selected = reactive({year_choices}),
+                           colwidth = 3)
+
+
+  # ### Flag Selection
+  #
+  # # Choices
+  # flag_choices <- Df2$FlagCode %>% factor() %>% levels()
+  #
+  # # Server
+  # Flag <- callModule(SELECT_SELECT_ALL, "flag",
+  #                    label = "Flags:",
+  #                    choices = reactive({flag_choices}),
+  #                    selected = reactive({flag_choices}),
+  #                    colwidth = 3,
+  #                    hidden = TRUE)
 
 
   ### Storm Selection
 
-  # Choices
-  storm_choices <- dfs[[1]]$StormSample %>% factor() %>% levels()
+  # # Choices
+  # storm_choices <- dfs[[1]]$StormSample %>% factor() %>% levels()
+  #
+  # # Server
+  # Storm <- callModule(CHECKBOX_SELECT_ALL, "storm",
+  #                     label = "Storm Sample:",
+  #                     choices = reactive({storm_choices}),
+  #                     selected = reactive({storm_choices}),
+  #                     hidden = TRUE)
 
-  # Server
-  Storm <- callModule(CHECKBOX_SELECT_ALL, "storm",
-                      label = "Storm Sample:",
-                      choices = reactive({storm_choices}),
-                      selected = reactive({storm_choices}),
-                      hidden = TRUE)
-  
-  
+
   ### Reactive List of (non-reactive) Dataframes - filter for selected site, param, value range, date, and remove rows with NA for Result
-  
-  Df_List <- reactive({
-    
-    req(input$date, Month(), Year()) #, Flag(), Storm() # See General Note _
-    
-    dfs %>% lapply(. %>% filter(Date > input$date[1], Date < input$date[2],
-                                as.character(month(Date, label = TRUE, abbr = FALSE)) %in% Month(),
-                                year(Date) %in% Year(),
-                                #FlagCode %in% Flag(),
-                                #StormSample %in% Storm(),
-                                !is.na(Result)))
+
+  Df3 <- reactive({
+
+    req(Month(), Year()) #, Flag(), Storm() # See General Note _
+
+    Df2() %>% filter(as.character(month(Date, label = TRUE, abbr = FALSE)) %in% Month(),
+                   year(Date) %in% Year(),
+                   #FlagCode %in% Flag(),
+                   #StormSample %in% Storm(),
+                   !is.na(Result))
   })
-  
-   
+
+
   ### Texts
-  
+
   output$text_no_month <- renderText({
     req(is.null(Month()))
-    "- Please Select Months"
-  })
-  
-  output$text_no_year <- renderText({
-    req(is.null(Year()))
-    "- Please Select Years"
-  })
-  
-  output$text_no_flag <- renderText({
-    req(is.null(Flag()))
-    "- Please Select Flag Types"
+    "- Select Months"
   })
 
-  output$text_no_storm <- renderText({
-    req(is.null(Storm()))
-    "- Please Select Storm Sample Types"
+  output$text_no_year <- renderText({
+    req(is.null(Year()))
+    "- Select Years"
   })
+
+  # output$text_no_flag <- renderText({
+  #   req(is.null(Flag()))
+  #   "- Please Select Flag Types"
+  # })
+  #
+  # output$text_no_storm <- renderText({
+  #   req(is.null(Storm()))
+  #   "- Please Select Storm Sample Types"
+  # })
 
 
   ### Return List of Reactive Dataframes
   # a Reactive List Expression is converted to a (Non-reactive) List of Reactive Expressions
-  
-  return(list(reactive({Df_List()[[1]]}),
-              reactive({Df_List()[[2]]}),
-              reactive({Df_List()[[3]]})))
-  
-  
+
+
+  # Reactive Dataframe - Wide Format (for Correlation ScatterPlot and Correlation Matrix)
+  Df3_Wide <- reactive({
+    Df3() %>%
+      select(-Units) %>%
+      distinct(LocationLabel, Date, Parameter, .keep_all = TRUE) %>%
+      spread("Parameter", "Result")
+  })
+
+  # Reactive Dataframe - Wide Format (for Correlation ScatterPlot and Correlation Matrix)
+  Df3_Stat <- reactive({
+    Df3() %>%
+      mutate(Year = factor(lubridate::year(Date)),
+             Season = getSeason(Date),
+             Month = month.abb[lubridate::month(Date)])
+  })
+
+
+
+  return(list(Long = Df3,
+              Wide = Df3_Wide,
+              Stat = Df3_Stat))
+
+  # return(list(Long = reactive({Df3()}),
+  #             Wide = reactive({Df3_Wide()}),
+  #             Stat = reactive({Df3_Stat()})))
+
+
 } # end Server Function
 

--- a/modules1/map_plot.R
+++ b/modules1/map_plot.R
@@ -5,24 +5,24 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
-#   1. If Statement makes sure that the dataframe is not empty in order for the colorpal to run. 
-#      The aim is to prevent potential crash. Further investigation could be: Is this neccesary?, 
+# Notes:
+#   1. If Statement makes sure that the dataframe is not empty in order for the colorpal to run.
+#      The aim is to prevent potential crash. Further investigation could be: Is this neccesary?,
 #      If so, better alternative? Do we need to assign an else to colorpal (in the case where no colorpal exists (the first click)).
 #      Think it's only neccesary in the latter location
 #   2. Factor Scheme in which is For the sizing Range of the Circles. Max Value in the determination of the Scale.
-#      This allows unity of the largest circle size (corresponding to the max value of the Statistic data selected. 
-#      The formula also has multipliing constant "30" to make the circles a reasonable size, and adds "10" to mainly 
+#      This allows unity of the largest circle size (corresponding to the max value of the Statistic data selected.
+#      The formula also has multipliing constant "30" to make the circles a reasonable size, and adds "10" to mainly
 #      make sure one cannot make the circles too small and disappear
 #   3. The Base Leaflet Map contains the Map Tiles and the Boudary Lat/Long info. This Base Leaflet Map is not dependent
 #      on any reactive objects or inputs (except for the map type input). Therefore the base map should not dissapear
 #      and be regerated during the any change in Selected Data or Display settings except for when map type is changed.
-#   4. If one changes the preffered initial map type (Tile), one needs to change it in the UI and also in the Base Leaflet  
-#      Map section of the Server Function. The reason why the input is not directly used in the Base Leaflet Map section  
+#   4. If one changes the preffered initial map type (Tile), one needs to change it in the UI and also in the Base Leaflet
+#      Map section of the Server Function. The reason why the input is not directly used in the Base Leaflet Map section
 #      is becuase the Lat/Long coordinates would be reset, which is likely undesired.
 #
 # To-Do List:
-#   2. Make a more precise sig fig method for statistic (i.e. Number of Samples should not be rounded (maybe keep all 
+#   2. Make a more precise sig fig method for statistic (i.e. Number of Samples should not be rounded (maybe keep all
 #      non-decimal numbers))
 #   3. Crashed with color numeric when selected variance
 
@@ -30,15 +30,15 @@
 # User Interface
 ##############################################################################################################################
 
-MAP_PLOT_UI <- function(id, df) { 
+MAP_PLOT_UI <- function(id, df) {
 
 ns <- NS(id)
 
 tagList(
-  
+
   # CSS for map / map legend
   tags$head(
-    tags$style(type = "text/css", 
+    tags$style(type = "text/css",
                # CSS for Map height to adjust to screen height
                "#mod_trib_quab_map-map {height: calc(100vh - 235px) !important;}",
                "#mod_trib_ware_map-map {height: calc(100vh - 235px) !important;}",
@@ -56,26 +56,21 @@ tagList(
           ") # end tags style
   ), # end tags head
   # end CSS
-  
+
     sidebarLayout(position = "right",
       sidebarPanel(width = 3,
         tabsetPanel(
           # Main Panel Options
           tabPanel("Main",
                    br(), br(), # Line Breaks
-                   # Choose Filtered or unfiltered data
-                   radioButtons(ns("df_choice"), "Full or Filtered Data:", 
-                                choices = c("full", "filtered"),
-                                inline = TRUE),
-                   p(textOutput(ns("text_filtered"))),
                    # Parameter Selection
-                   selectInput(ns("param"), "Water Quality Parameter:",        
+                   selectInput(ns("param"), "Water Quality Parameter:",
                                choices=c("-Select Parameter-", levels(factor(df$Parameter))),
                                selected = "-Select Parameter-"),
                    hr(), # Horizontal Rule/Line
                    # Statistic Selection
-                   selectInput(ns("stat"), "Value Statistic:",        
-                               choices=c("average", "minimum", "maximum", 
+                   selectInput(ns("stat"), "Value Statistic:",
+                               choices=c("average", "minimum", "maximum",
                                          "median", "1st quartile", "1st quartile",
                                          "variance", "stand. dev.","number of samples", "geometric mean"),
                                selected = "average"),
@@ -85,11 +80,11 @@ tagList(
                    br(), br(),
                    wellPanel(
                    # Year
-                     selectInput(ns("year"), "Year:", 
-                                 choices = c("All Years", rev(year(seq(as.Date("1980-1-1"), Sys.Date(), "years")))), 
+                     selectInput(ns("year"), "Year:",
+                                 choices = c("All Years", rev(year(seq(as.Date("1980-1-1"), Sys.Date(), "years")))),
                                  selected = "All Years"),
                      # Month
-                     selectInput(ns("month"), "Month:", 
+                     selectInput(ns("month"), "Month:",
                                  choices = c("All Months", month.name[1:12]),
                                  selected = "All Months")
                    ) # end Well Panel
@@ -98,7 +93,7 @@ tagList(
           tabPanel("Display",
                    br(), br(),
                    # Map Style
-                   selectInput(ns("map_type"), "Map Style:",        
+                   selectInput(ns("map_type"), "Map Style:",
                                choices=c(providers$Stamen.TonerLite,
                                          providers$CartoDB.Positron,
                                          providers$Esri.NatGeoWorldMap,
@@ -106,7 +101,7 @@ tagList(
                                selected = providers$Stamen.TonerLite), # See Note 4
                    hr(), # Horizontal Rule/Line
                    # Plot Style
-                   radioButtons(ns("plot_type"), "Plot Style:",        
+                   radioButtons(ns("plot_type"), "Plot Style:",
                                choices=c("Display by Color", "Display by Size"),
                                selected = "Display by Color"),
                    br(),
@@ -136,66 +131,57 @@ tagList(
         leafletOutput(ns("map"), height = 800)
       ) # end Main Panel
     ) # end sidebarlayout
-  ) # end taglist     
+  ) # end taglist
 } # end UI function
 
 ##############################################################################################################################
 # Server Function
 ##############################################################################################################################
 
-# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value. 
+# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-MAP_PLOT <- function(input, output, session, df_full, Df_Filtered, df_site) {
-  
+MAP_PLOT <- function(input, output, session, df, df_site) {
+
   ns <- session$ns # see General Note 1
-  
+
   # Create a more condensed Site Location dataframe (with Lat,lomg,site ID)
   df_site2 <- df_site %>% select(Site, LocationLat, LocationLong)
-  
-  # Dataframe filtered or full based on Selection
-  Df1 <- reactive({
-    if(input$df_choice == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
+
   ### Render UIs
-  
+
   # Parameter Axis Choice for Secondary Axis
   output$color_dynamic_ui <- renderUI({
     req(input$plot_type == "Display by Color")
-    radioButtons(ns("color_dynamic"), "Color Scheme:",        
+    radioButtons(ns("color_dynamic"), "Color Scheme:",
                  choices= c("Spectral", "RdYlBu", "Greens", "Greys", "Oranges", "Blues"),
                  inline = TRUE)
   })
-  
+
   outputOptions(output, "color_dynamic_ui", suspendWhenHidden = FALSE) # see Dev. Manual
-  
+
   # Parameter Axis Choice for Secondary Axis
   output$color_static_ui <- renderUI({
     req(input$plot_type == "Display by Size")
-    radioButtons(ns("color_static"), "Color:",        
+    radioButtons(ns("color_static"), "Color:",
                  choices=c("black", "blue", "red"),
                  selected = "blue",
                  inline = TRUE)
   })
-  
+
   outputOptions(output, "color_static_ui", suspendWhenHidden = FALSE) # see Dev. Manual
-  
-  
+
+
   ### Reactive Dataframe for data stats
-  
-  Df2 <- reactive({
-    
+
+  Df1 <- reactive({
+
     # Filter by Parameter and remove NAs
-    df_temp <- Df1() %>% 
-      filter(!is.na(Result), 
+    df_temp <- df %>%
+      filter(!is.na(Result),
              Parameter %in% input$param)
-    
+
     # Filter by Date
     if(input$year != "All Years"){
       df_temp <- df_temp %>% filter(year(Date) == input$year)
@@ -203,110 +189,110 @@ MAP_PLOT <- function(input, output, session, df_full, Df_Filtered, df_site) {
     if (input$month != "All Months"){
       df_temp <- df_temp %>% filter(month.name[month(Date)] == input$month)
     }
-    
+
     # Group by Site and add any statistics (Make sure this matches with UI options)
     df_temp <- df_temp %>% group_by(Site) %>%
       summarise(`number of samples` = n(),
-                average = mean(Result), 
-                minimum = min(Result), 
+                average = mean(Result),
+                minimum = min(Result),
                 maximum = max(Result),
                 `1st quartile` = quantile(Result, 0.25),
                 median = median(Result),
                 `3rd quartile` = quantile(Result, 0.75),
-                variance = var(Result), 
+                variance = var(Result),
                 `stand. dev.` = sd(Result),
                 `geometric mean` = gm_mean(Result)) %>%
       gather(Stat, Value, -c(Site)) # Restructuring the Stat Columns into Two new Columns: "Stat" and "Value"
-    
+
     # Join the two tables together mathched by site - now includes lat/long info
     df_temp <- inner_join(df_temp, df_site2, "Site") %>%
       filter(Stat %in% input$stat,
-             !is.na(LocationLat), 
+             !is.na(LocationLat),
              !is.na(LocationLong))
-    
+
     # Setting a 3 digit sig fig for Statistic Values
     df_temp$Value <- signif(df_temp$Value, 3)
-    
-    # Assiging df.temp to Df2
+
+    # Assiging df.temp to Df1
     df_temp
-    
-  }) # end Df2
-  
-  
+
+  }) # end Df1
+
+
 # Map - Color Pallete
-  
+
   Color_Pal <- reactive({
     req(input$color_dynamic)
     # If statement to prevent potential crash, See Note 1
-    if(nrow(Df2()) > 0){
-      colorNumeric(palette = input$color_dynamic, range(Df2()$Value))
+    if(nrow(Df1()) > 0){
+      colorNumeric(palette = input$color_dynamic, range(Df1()$Value))
     }
   }) # end colorpal
 
-  
+
 # Map - Size "Pallete" - For size legend creation.
-  
+
   Value_Min <- reactive({
-    signif(min(Df2()$Value),3)
+    signif(min(Df1()$Value),3)
   })
-  
+
   Value_Max <- reactive({
-    signif(max(Df2()$Value),3)
+    signif(max(Df1()$Value),3)
   })
-  
+
   # Create 8 circles for the legend. change 8 if desired number is different
   Value_List <- reactive({
     signif(seq(Value_Min(), Value_Max(), length.out = 8), 3)
   })
-  
+
   # Sizing Scheme for the Circles, See Note 2
   Value_Scale <- reactive({
     ((as.numeric(input$radius)*30)+10)/sqrt(Value_Max())
   })
-  
+
   Diam_List <- reactive({
     2*Value_Scale()*sqrt(Value_List())
   })
-  
+
 
 # Circle Legend function
-  
+
   addLegendCustom <- function(map, colors, labels, sizes, opacity = 0.5){
     colorAdditions <- paste0(colors, "; width:", sizes, "px; height:", sizes, "px")
-    labelAdditions <- paste0("<div style='display: inline-block;height: ", sizes, 
+    labelAdditions <- paste0("<div style='display: inline-block;height: ", sizes,
                              "px;margin-top: 4px;line-height: ", sizes, "px;'>", labels, "</div>")
     return(addLegend(map, colors = colorAdditions, labels = labelAdditions, opacity = opacity))
-  } 
+  }
 
 
 # Base Leaflet Map - See Note 3
-  
+
   output$map <- renderLeaflet({
     leaflet(data = df_site %>% filter(!is.na(LocationLat), !is.na(LocationLong))) %>%
-      addProviderTiles(providers$Stamen.TonerLite,  
+      addProviderTiles(providers$Stamen.TonerLite,
                        options = providerTileOptions(noWrap = TRUE)) %>%
       fitBounds(~min((LocationLong)), ~min(LocationLat), ~max(LocationLong), ~max(LocationLat))
   })
-  
-  
+
+
 # Map Proxy - Add the Circle Markers and Legend to the map. This is Reactive to events, unlike the Base Map.
-  
+
   observe({
-    
+
     # if Data Selected is empty, do not add markers. See Note 1
-    if(nrow(Df2()) > 0){
-    
+    if(nrow(Df1()) > 0){
+
       # Color
       if(input$plot_type == "Display by Color"){
-       
+
         pal <- Color_Pal()                                # load colorpal function
-        
-        leafletProxy("map", data = Df2()) %>%
+
+        leafletProxy("map", data = Df1()) %>%
           clearTiles() %>%
-          addProviderTiles(input$map_type,  
+          addProviderTiles(input$map_type,
                            options = providerTileOptions(noWrap = TRUE)) %>%
           clearMarkers() %>%
-          addCircleMarkers(lng = ~LocationLong, 
+          addCircleMarkers(lng = ~LocationLong,
                      lat = ~LocationLat,
                      radius = input$radius*15+5,          # user selected opacity
                      weight = .5,                         # weight of the outside circle
@@ -317,22 +303,22 @@ MAP_PLOT <- function(input, output, session, df_full, Df_Filtered, df_site) {
                      popup = ~Site) %>%                   # Show Site name when clicked
           clearControls() %>%
           addLegend(position = "topright",
-                    pal = pal, 
+                    pal = pal,
                     values = ~Value,
                     title = input$param,
                     opacity = 1)
       }
       # Size
       if(input$plot_type == "Display by Size"){
-        
-        leafletProxy("map", data = Df2()) %>%
+
+        leafletProxy("map", data = Df1()) %>%
           clearTiles() %>%
-          addProviderTiles(input$map_type,  
+          addProviderTiles(input$map_type,
                            options = providerTileOptions(noWrap = TRUE)) %>%
           clearMarkers() %>%
-          addCircleMarkers(lng = ~LocationLong, 
+          addCircleMarkers(lng = ~LocationLong,
                            lat = ~LocationLat,
-                           radius = ~Value_Scale()*sqrt(Value), # radius function of Value   
+                           radius = ~Value_Scale()*sqrt(Value), # radius function of Value
                            weight = 2,                          # weight of the outside circle
                            color = input$color_static,          # Color of the outside circle
                            fillColor = input$color_static,      # User selected fill Color
@@ -340,26 +326,20 @@ MAP_PLOT <- function(input, output, session, df_full, Df_Filtered, df_site) {
                            label= ~as.character(Value),         # show Value when hovering
                            popup = ~Site) %>%                   # Show Site name when clicked
           clearControls() %>%
-          addLegendCustom(colors = c(input$color_static, input$color_static, input$color_static), 
+          addLegendCustom(colors = c(input$color_static, input$color_static, input$color_static),
                           labels = Value_List(),
                           sizes = Diam_List(),
                           opacity = .7)
       }
-    # If no data, then clear the existing circleMarkers and legend  
+    # If no data, then clear the existing circleMarkers and legend
     } else {
-      leafletProxy("map", data = Df2()) %>%
+      leafletProxy("map", data = Df1()) %>%
         clearMarkers() %>%
         clearControls()
     }
   })
-  
-  
-  
-  # Text - Filtered Data
-  output$text_filtered <- renderText({
-    req(input$df_choice == "filtered") # See General Note 1
-    'This Dataset has been filtered and therefore some observations (data points) may be excluded.\n See "Filtered tab"'
-  })
-  
+
+
+
 } # end Server Funtion
 

--- a/modules1/metadata.R
+++ b/modules1/metadata.R
@@ -5,7 +5,7 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
+# Notes:
 #   1. req() will delay the rendering of a widget or other reactive object until a certain logical expression is TRUE or not NULL
 #
 # To-Do List:
@@ -17,16 +17,16 @@
 ##############################################################################################################################
 
 METADATA_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
     tabsetPanel(
       tabPanel("Location",
                fluidRow(
                  dataTableOutput(ns("table_site"))
                ), # end Fluid Row
-               br(), 
+               br(),
                br(),
                wellPanel(
                  fluidRow(
@@ -34,7 +34,6 @@ METADATA_UI <- function(id) {
                           SITE_MAP_UI(ns("site_map"))
                    ),
                    column(6,
-                          uiOutput(ns("df_choice_site_ui")),
                           tableOutput(ns("table_site_stat")),
                           h3(textOutput(ns("site_text_null"))),
                           h3(textOutput(ns("site_text_select")))
@@ -49,13 +48,12 @@ METADATA_UI <- function(id) {
                fluidRow(
                  dataTableOutput(ns("table_param"))
                ), # end Fluid Row
-               br(), 
+               br(),
                br(),
                wellPanel(
                  fluidRow(
                    column(1),
                    column(10,
-                          uiOutput(ns("df_choice_param_ui")),
                           tableOutput(ns("table_param_stat")),
                           h3(textOutput(ns("param_text_null"))),
                           h3(textOutput(ns("param_text_select")))
@@ -63,27 +61,27 @@ METADATA_UI <- function(id) {
                    column(1)
                  )
                ) # end Fluid Row
-      ),
-      tabPanel("Flags Codes",
-               fluidRow(
-                 dataTableOutput(ns("table_flag"))
-               ), # end Fluid Row
-               br(), 
-               br(),
-               wellPanel(
-                 fluidRow(
-                   column(3),
-                   uiOutput(ns("df_choice_flag_ui")),
-                   uiOutput(ns("flag_grouping_ui")),
-                   column(9,
-
-                          tableOutput(ns("table_flag_stat")),
-                          h3(textOutput(ns("flag_text_null"))),
-                          h3(textOutput(ns("flag_text_select")))
-                   )
-                 )
-               ) # end Fluid Row
-      )
+      )#,
+      # tabPanel("Flags Codes",
+      #          fluidRow(
+      #            dataTableOutput(ns("table_flag"))
+      #          ), # end Fluid Row
+      #          br(),
+      #          br(),
+      #          wellPanel(
+      #            fluidRow(
+      #              column(3),
+      #              uiOutput(ns("df_choice_flag_ui")),
+      #              uiOutput(ns("flag_grouping_ui")),
+      #              column(9,
+      #
+      #                     tableOutput(ns("table_flag_stat")),
+      #                     h3(textOutput(ns("flag_text_null"))),
+      #                     h3(textOutput(ns("flag_text_select")))
+      #              )
+      #            )
+      #          ) # end Fluid Row
+      # )
     )
   ) # end taglist
 } # end UI function
@@ -94,55 +92,45 @@ METADATA_UI <- function(id) {
 ##############################################################################################################################
 
 # This module takes df as a reactive expressions. Changes will have to be made to accmodate reactive expressions
-# 
+#
 
-METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df_flag = NULL, df_full, Df_Filtered) {
-  
+METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df) {
+
   ns <- session$ns # see General Note 1
-  
+
   ### Primary Tables
-  
-  output$table_site <- renderDataTable(df_site, selection = 'single', 
+
+  output$table_site <- renderDataTable(df_site, selection = 'single',
                                        options = list(lengthMenu = c(5, 10, 50), pageLength = 5))
-  
+
   output$table_param <- renderDataTable(df_param, selection = 'single',
                                         options = list(lengthMenu = c(5, 10, 50), pageLength = 5))
-  
-  output$table_flag <- renderDataTable(df_flag, selection = 'single')
-  
-  
+
+  #output$table_flag <- renderDataTable(df_flag, selection = 'single')
+
+
   ### Additonal Site Info
-  
+
   # Selected row from DT
   Site_Selected <- reactive({
     req(input$table_site_rows_selected)
     df_site[input$table_site_rows_selected, ]
   })
-  
+
   # UI for Full or filtered choice
   output$df_choice_site_ui <- renderUI({
     req(Site_Selected())
-    radioButtons(ns("df_choice_site"), "Full or Filtered Data:", 
+    radioButtons(ns("df_choice_site"), "Full or Filtered Data:",
                  choices = c("full", "filtered"),
                  inline = TRUE)
   })
-  
-  # Dataframe filtered or full based on Selection
-  Df_For_Site <- reactive({
-    req(input$df_choice_site)
-    if(input$df_choice_site == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
+
   # Site Map
   callModule(SITE_MAP_SINGLE, "site_map", Site = Site_Selected)
-  
+
   # Site Overview Table
   Df_Site_Info_a <- reactive({
-    Df_For_Site() %>%
+    Df() %>%
       filter(LocationLabel %in% Site_Selected()$LocationLabel) %>%
       summarise(`Parameter` = "ALL",
                 `Number of Samples` = n(),
@@ -151,9 +139,9 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
                 `Latest Result` = NA,
                 `Units` = NA)
   })
-  
+
   Df_Site_Info_b <- reactive({
-    Df_For_Site() %>%
+    Df() %>%
       filter(LocationLabel %in% Site_Selected()$LocationLabel) %>%
       group_by(Parameter) %>%
       summarise(`Number of Samples` = n(),
@@ -162,66 +150,56 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
                 `Latest Result` = Result[Date == max(Date)],
                 `Units` = Units[Date == max(Date)])
   })
-  
+
   Df_Site_Info <- reactive({rbind(Df_Site_Info_a(), Df_Site_Info_b())})
 
   output$table_site_stat <- renderTable({
     req(Site_Selected())
     Df_Site_Info()
     })
-  
+
   # Site Image
   output$river_image <- renderImage({
     req(Site_Selected()) # can delete once Site_Selected is used in renderImage due to earlier req()
-    
+
     list(src = "images/river.jpg",
          width="100%",
          height= "350")
   }, deleteFile = FALSE)
-  
+
   # Site Text - when no site table is given to module
   output$site_text_null <- renderText({
     req(is.null(df_site))
     "SELECT a ROW above to see MORE INFO on a LOCATION"
   })
-  
+
   # Site Text - when no site is selected
   output$site_text_select <- renderText({
     req(!isTruthy(input$table_site_rows_selected))
     "SELECT a ROW above to see MORE INFO on a LOCATION"
   })
-  
-  
-  
+
+
+
   ### Additional Parameter Info Table
-  
+
   # Selected row from DT
   Param_Selected <- reactive({
     req(input$table_param_rows_selected)
     df_param[input$table_param_rows_selected, ]
   })
-  
+
   # UI for Full or filtered choice
   output$df_choice_param_ui <- renderUI({
     req(Param_Selected())
-    radioButtons(ns("df_choice_param"), "Full or Filtered Data:", 
+    radioButtons(ns("df_choice_param"), "Full or Filtered Data:",
                  choices = c("full", "filtered"),
                  inline = TRUE)
   })
-  
-  # Dataframe filtered or full based on Selection
-  Df_For_Param <- reactive({
-    req(input$df_choice_param)
-    if(input$df_choice_param == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
+
   # param Overview Table
   Df_Param_Info_a <- reactive({
-    Df_For_Param() %>%
+    Df() %>%
       filter(Parameter %in%  Param_Selected()$ParameterName) %>%
       summarise(`LocationLabel` = "ALL",
                 `Number of Samples` = n(),
@@ -230,9 +208,9 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
                 `Latest Result` = NA,
                 `Units` = NA)
   })
-    
+
   Df_Param_Info_b <- reactive({
-    Df_For_Param() %>%
+    Df() %>%
       filter(Parameter %in%  Param_Selected()$ParameterName) %>%
       group_by(LocationLabel) %>%
       summarise(`Number of Samples` = n(),
@@ -241,7 +219,7 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
                 `Latest Result` = Result[Date == max(Date)],
                 `Units` = Units[Date == max(Date)])
   })
-  
+
   Df_Param_Info <- reactive({rbind(Df_Param_Info_a(), Df_Param_Info_b())})
 
   output$table_param_stat <- renderTable(Df_Param_Info())
@@ -251,82 +229,73 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
     req(is.null(df_param))
     "No Parameter Table available. Please set up"
   })
-  
+
   # Param Text - when no site is selected
   output$param_text_select <- renderText({
     req(!isTruthy(input$table_param_rows_selected))
     "SELECT a ROW above to see MORE INFO on a PARAMETER"
   })
-  
 
-  
-  ### Additional Flag Info Table
-  
-  # Selected row from DT
-  Flag_Selected <- reactive({
-    req(input$table_flag_rows_selected)
-    df_flag[input$table_flag_rows_selected, ]
-  })
-  
-  # UI for Full or filtered choice
-  output$df_choice_flag_ui <- renderUI({
-    req(Flag_Selected())
-    radioButtons(ns("df_choice_flag"), "Full or Filtered Data:", 
-                 choices = c("full", "filtered"),
-                 inline = TRUE)
-  })
-  
-  # Dataframe filtered or full based on Selection
-  Df_For_Flag <- reactive({
-    req(input$df_choice_flag)
-    if(input$df_choice_flag == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
-  # UI for grouping type
-  output$flag_grouping_ui <- renderUI({
-    req(Flag_Selected())
-    radioButtons(ns("flag_grouping"), "Flag Grouping:", 
-                 choices = c("None" = "None",
-                             "Site" = c("LocationLabel"), 
-                             "Parameter" = c("LocationLabel", "Parameter"),
-                             "Site and Parameter" = c("LocationLabel", "Parameter"),
-                             "Parameter and Site" = c("Parameter", "LocationLabel"))
-                 )
-  })
-  
-  
-  Df_Flag_Info <- reactive({
-   
-    df_temp <- Df_For_Flag() %>% filter_(!is.null(paste0("Flag", Flag_Selected()$Flag_ID)))
-    
-    if(input$flag_grouping == "None"){
-      df_temp <- df.temp
-    }else{
-      df_temp <- group_by_(.dots = input$flag_grouping)
-    }
-    
-    df_temp %>% summarise(`Number of Samples` = n(),
-                          `Start Date` = as.character(min(Date)), # need as.character becuase of renderTable has a bug for Date Class (xtable bug)
-                          `End Date` = as.character(max(Date)))
-  })
-  
-  
-  # Flag Text - when no site table is given to module
-  output$flag_text_null <- renderText({
-    req(is.null(df_flag))
-    "No Flag Code Table available. Please set up"
-  })
-  
-  # Flag Text - when no site is selected
-  output$flag_text_select <- renderText({
-    req(!isTruthy(input$table_flag_rows_selected))
-    "SELECT a ROW above to see MORE INFO on a Flag Code"
-  })
-  
-  
+
+
+  # ### Additional Flag Info Table
+  #
+  # # Selected row from DT
+  # Flag_Selected <- reactive({
+  #   req(input$table_flag_rows_selected)
+  #   df_flag[input$table_flag_rows_selected, ]
+  # })
+  #
+  # # UI for Full or filtered choice
+  # output$df_choice_flag_ui <- renderUI({
+  #   req(Flag_Selected())
+  #   radioButtons(ns("df_choice_flag"), "Full or Filtered Data:",
+  #                choices = c("full", "filtered"),
+  #                inline = TRUE)
+  # })
+  #
+  #
+  # # UI for grouping type
+  # output$flag_grouping_ui <- renderUI({
+  #   req(Flag_Selected())
+  #   radioButtons(ns("flag_grouping"), "Flag Grouping:",
+  #                choices = c("None" = "None",
+  #                            "Site" = c("LocationLabel"),
+  #                            "Parameter" = c("LocationLabel", "Parameter"),
+  #                            "Site and Parameter" = c("LocationLabel", "Parameter"),
+  #                            "Parameter and Site" = c("Parameter", "LocationLabel"))
+  #                )
+  # })
+  #
+  #
+  # Df_Flag_Info <- reactive({
+  #
+  #   df_temp <- Df() %>% filter_(!is.null(paste0("Flag", Flag_Selected()$Flag_ID)))
+  #
+  #   if(input$flag_grouping == "None"){
+  #     df_temp <- df.temp
+  #   }else{
+  #     df_temp <- group_by_(.dots = input$flag_grouping)
+  #   }
+  #
+  #   df_temp %>% summarise(`Number of Samples` = n(),
+  #                         `Start Date` = as.character(min(Date)), # need as.character becuase of renderTable has a bug for Date Class (xtable bug)
+  #                         `End Date` = as.character(max(Date)))
+  # })
+  #
+  #
+  # # Flag Text - when no site table is given to module
+  # output$flag_text_null <- renderText({
+  #   req(is.null(df_flag))
+  #   "No Flag Code Table available. Please set up"
+  # })
+  #
+  # # Flag Text - when no site is selected
+  # output$flag_text_select <- renderText({
+  #   req(!isTruthy(input$table_flag_rows_selected))
+  #   "SELECT a ROW above to see MORE INFO on a Flag Code"
+  # })
+
+
 } # end Server Function
 

--- a/modules1/metadata.R
+++ b/modules1/metadata.R
@@ -130,7 +130,7 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
 
   # Site Overview Table
   Df_Site_Info_a <- reactive({
-    Df() %>%
+    df %>%
       filter(LocationLabel %in% Site_Selected()$LocationLabel) %>%
       summarise(`Parameter` = "ALL",
                 `Number of Samples` = n(),
@@ -141,7 +141,7 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
   })
 
   Df_Site_Info_b <- reactive({
-    Df() %>%
+    df %>%
       filter(LocationLabel %in% Site_Selected()$LocationLabel) %>%
       group_by(Parameter) %>%
       summarise(`Number of Samples` = n(),
@@ -199,7 +199,7 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
 
   # param Overview Table
   Df_Param_Info_a <- reactive({
-    Df() %>%
+    df %>%
       filter(Parameter %in%  Param_Selected()$ParameterName) %>%
       summarise(`LocationLabel` = "ALL",
                 `Number of Samples` = n(),
@@ -210,7 +210,7 @@ METADATA <- function(input, output, session, df_site = NULL, df_param = NULL, df
   })
 
   Df_Param_Info_b <- reactive({
-    Df() %>%
+    df %>%
       filter(Parameter %in%  Param_Selected()$ParameterName) %>%
       group_by(LocationLabel) %>%
       summarise(`Number of Samples` = n(),

--- a/modules1/time_depth_wq.R
+++ b/modules1/time_depth_wq.R
@@ -5,8 +5,8 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
-#   1. 
+# Notes:
+#   1.
 #
 # To-Do List:
 #   1. Add Reactive Parameter Units to the Value Bars. This includes removing the units from the dataframe and
@@ -22,46 +22,19 @@
 ##############################################################################################################################
 
 TIME_DEPTH_WQ_UI <- function(id) {
-  
+
 ns <- NS(id)
 
 tagList(
-  wellPanel(
-    fluidRow(
-      column(4,
-             radioButtons(ns("df_choice"), "Full or Filtered Data:", 
-                          choices = c("full", "filtered"),
-                          inline = TRUE),
-             conditionalPanel(
-               condition = paste0("input['", ns("dfchoice"), "'] == 'filtered'"), 
-               p('This Dataset has been filtered and therefore some observations (data points) may be excluded.\n See "Filtered tab"')
-             ),
-             uiOutput(ns("text_select")),
-             wellPanel(
-               SITE_MAP_UI(ns("site_map"))
-             ) # end Well Panel
-      ), # end Column
-      column(4,
-             # Station and Level Selection
-             uiOutput(ns("site_ui"))
-      ), # end Column
-      column(4,
-             uiOutput(ns("param_ui")),
-             br(),
-             # Date Selection
-             uiOutput(ns("date_ui"))
-      ) # end column
-    ) # end Fluid Row
-  ), # Well Panel
-  
+
   # Tabset panel for plots, tables, Summary Stats
   tabsetPanel(
-    
+
     # Plot tab
-    tabPanel("Plot", 
+    tabPanel("Plot",
              PLOT_TIME_DEPTH_WQ_UI(ns("plot"))
     ),
-    
+
     # Table Tab
     tabPanel("Table",
              # first row - print button, etc
@@ -75,7 +48,7 @@ tagList(
                dataTableOutput(ns("table"))
              ) # end fluid row
     ), # end tabpanel
-    
+
     tabPanel("Summary",
              STAT_TIME_DEPTH_WQ_UI(ns("stat"))
     ) # end Tab Panel - Summary
@@ -88,156 +61,38 @@ tagList(
 # Server Function
 ##############################################################################################################################
 
-# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value. 
+# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-TIME_DEPTH_WQ <- function(input, output, session, df_full, Df_Filtered, df_site) {
-  
-  ns <- session$ns # see General Note 1
-  
-  ### Dataframe filtered or full based on Selection
-  
-  Df1 <- reactive({
-    if(input$df_choice == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
-  
-  
-  ### Site Selection using Site Select Module
-  
-  # Ui
-  output$site_ui <- renderUI({
-    STATION_LEVEL_CHECKBOX_UI(ns("site"))
-  })
-  
-  # Server
-  Site <- callModule(STATION_LEVEL_CHECKBOX, "site", Df = Df1)
-  
-  
-  
-  ### Parameter Selection using ParameterSelect Module
-  
-  # Ui
-  output$param_ui <- renderUI({
-    PARAM_SELECT_UI(ns("param"))
-  })
-  
-  # Server
-  Param <- callModule(PARAM_SELECT, "param", Df = Df1, Site = Site)
-  
-  
-  
-  ### Date Range Selection Using DateSelect Module
-  
-  # Ui
-  output$date_ui <- renderUI({
-    DATE_SELECT_UI(ns("date"))
-  })
-  
-  # Server
-  Date <- callModule(DATE_SELECT, "date", Df = Df1, Site = Site)
-  
-  
-  
-  
-  ### Reactive Dataframe - filter for selected site, param, value range, date, and remove rows with NA for Result
-  
-  Df2 <- reactive({
-    
-    req(Site(), Param$Type(), Param$Range_Min(), Param$Range_Min(), Date$Lower(), Date$Upper()) # See General Note _
-    
-    Df1() %>% 
-      filter(LocationLabel %in% Site(), 
-             Parameter %in% Param$Type(), 
-             Result > Param$Range_Min(), Result < Param$Range_Max(),
-             Date > Date$Lower(), Date < Date$Upper(),
-             !is.na(Result))
-  })
-  
-  
-  
-  
-  ### Texts
-  
-  # Text Output
-  output$text_select <- renderUI({
-    # Text - Number of Samples or "Select a site"
-    wellPanel(
-      h5(textOutput(ns("text_site_null")), align = "center"),
-      h5(textOutput(ns("text_param_null")), align = "center"),
-      h5(textOutput(ns("text_date_null")), align = "center"),
-      h5(textOutput(ns("text_num_text")), align = "center"),
-      strong(textOutput(ns("text_num")), align = "center")
-    ) # end Well Panel
-  })
-  
-  # Text - Select Site
-  output$text_site_null <- renderText({
-    req(is.null(Site())) # See General Note 1
-    "Select Site(s)"
-  })
-  
-  # Text - Select Param
-  output$text_param_null <- renderText({
-    req(Param$Type() == "") # See General Note 1
-    "Select Parameter"
-  })
-  
-  # Text - Select Param
-  output$text_date_null <- renderText({
-    req(any(is.null(Date$Lower()), is.null(Date$Upper()))) # See General Note 1
-    "Select Lower Date Range"
-  })
-  
-  # Text - Number of Samples - Words
-  output$text_num_text <- renderText({
-    req(Site(), Param$Type()) # See General Note 1
-    "Number of Samples in Selected Data:"
-  })
-  
-  # Text - Number of Samples - Number
-  output$text_num <- renderText({
-    req(Df2()) # See General Note 1
-    Df2() %>% summarise(n()) %>% paste()
-  })
-  
-  
-  
+TIME_DEPTH_WQ <- function(input, output, session, Df) {
+
+
   ### Plot
 
-  callModule(PLOT_TIME_DEPTH_WQ, "plot", Df = Df2)
-  
+  callModule(PLOT_TIME_DEPTH_WQ, "plot", Df = Df)
+
 
   ### Table
-  
-  output$table <- renderDataTable(Df2())
-  
-  
+
+  output$table <- renderDataTable(Df())
+
+
   ### Summary Statistics
-  
-  callModule(STAT_TIME_DEPTH_WQ, "stat", Df = Df2)
-  
-  
-  ### Site Map
-  
-  callModule(SITE_MAP, "site_map", df_site = df_site, Site_List = Site)
-  
-  
+
+  callModule(STAT_TIME_DEPTH_WQ, "stat", Df = Df)
+
+
   ### Downloadable csv of selected dataset
-  
+
   output$download_data <- downloadHandler(
     filename = function() {
       paste("DCRExportedWQData", ".csv", sep = "")
     },
     content = function(file) {
-      write_csv(Df2(), file)
+      write_csv(Df(), file)
     }
   )
-  
+
 } # end server
 

--- a/modules1/time_wq.R
+++ b/modules1/time_wq.R
@@ -79,31 +79,7 @@ TIME_WQ <- function(input, output, session, Df) {
   callModule(STAT_TIME_WQ, "stats", Df = Df)
 
 
-  ### Downloadable csv of selected dataset
 
-  output$download_data <- downloadHandler(
-    filename = function() {
-      paste("DCRExportedWQData", ".csv", sep = "")
-    },
-    content = function(file) {
-      write_csv(Df_Table(), file)
-    }
-  )
-
-
-  # Column Selection for table output
-  output$column_ui <- renderUI({
-    checkboxGroupInput(ns("column"), "Table Columns:",
-                       choices = names(Df()),
-                       selected = names(Df()),
-                       inline = TRUE)
-  })
-
-  # Df for Table
-  Df_Table <- reactive({
-    req(input$column)
-    Df() %>% select(c(input$column))
-  })
 
 
 

--- a/modules1/time_wq.R
+++ b/modules1/time_wq.R
@@ -5,82 +5,51 @@
 #     Written by: Nick Zinck, Spring 2017
 ##############################################################################################################################
 
-# Notes: 
-# 
+# Notes:
+#
 
 ##############################################################################################################################
 # User Interface
 ##############################################################################################################################
 
 TIME_WQ_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
-    wellPanel(       
-      fluidRow(
-        column(3,
-               radioButtons(ns("df_choice"), "Full or Filtered Data:", 
-                            choices = c("full", "filtered"),
-                            inline = TRUE),
-               p(textOutput(ns("text_filtered"))),
-               wellPanel(
-                 h4(textOutput(ns("text_site_null")), align = "center"),
-                 h4(textOutput(ns("text_param_null")), align = "center"),
-                 h4(textOutput(ns("text_date_null")), align = "center"),
-                 h5(textOutput(ns("text_num_text")), align = "center"),
-                 strong(textOutput(ns("text_num")), align = "center")
-               ), # end Well Panel
-               wellPanel(
-                 SITE_MAP_UI(ns("site_map"))
-               ) # end Well Panel
-        ), # end Column
-        column(6,
-               SITE_CHECKBOX_UI(ns("site"))
-        ), # end Column
-        column(3,
-               PARAM_SELECT_UI(ns("param")),
-               br(),
-               DATE_SELECT_UI(ns("date"))
-        ) # end column
-      ) # end fluidrow     
-    ), # end well panel
-    
-    # Tabset panel for plots, tables, etc. 
+
+    # Tabset panel for plots, tables, etc.
     tabsetPanel(
-      
+
       # Plot Tab
       tabPanel("Plot",
-               h4(textOutput(ns("text_plot_no_data"))),
-               h4(textOutput(ns("text_plot_zero_data"))),
+               # h4(textOutput(ns("text_plot_zero_data"))),
                PLOT_TIME_WQ_UI(ns("plot"))
       ), # end Tab Panel - Plot
-      
+
       # Table Tabpanel
       tabPanel("Table",
-               h4(textOutput(ns("text_table_no_data"))),
-               h4(textOutput(ns("text_table_zero_data"))),
+               # h4(textOutput(ns("text_table_zero_data"))),
                fluidRow(br(),
                         column(3,
                                downloadButton(ns("download_data"), "Download table as csv")
                         ),
-                        column(9, 
+                        column(9,
                                uiOutput(ns("column_ui"))
-                        ), 
+                        ),
                         br()
                ), # end Fluid Row
                fluidRow(
                  dataTableOutput(ns("table"))
                ) # end Fluid Row
       ), # end Tab Panel - Table
-      
+
       # Summary Tabpanel
       tabPanel("Stats",
-               h4(textOutput(ns("text_stats_no_data"))),
-               h4(textOutput(ns("text_stats_zero_data"))),
+               # h4(textOutput(ns("text_zero_data"))),
                STAT_TIME_WQ_UI(ns("stats"))
       ) # end Tab Panel - Summary
-      
+
     ) # end tabsetpanel (plots, stats, etc.)
   ) # end taglist
 } # end UI function
@@ -90,76 +59,28 @@ TIME_WQ_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value. 
+# Note that Argument "df.filtered"  needs to be a reactive expression, not a resolved value.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-TIME_WQ <- function(input, output, session, df_full, Df_Filtered, df_site) {
-  
-  ns <- session$ns # see General Note 1
-  
-  # Dataframe filtered or full based on Selection
-  Df1 <- reactive({
-    if(input$df_choice == "filtered"){
-      Df_Filtered()
-    }else{
-      df_full
-    }
-  })
-  
-  
-  # Site Selection using Site Select Module
-  Site <- callModule(SITE_CHECKBOX, "site", Df = Df1)
-  
-  
-  # Reactive Dataframe - first filter of the dataframe for Site
-  Df2 <- reactive({
-    req(Site())
-    
-    Df1() %>% 
-      filter(LocationLabel %in% Site(),
-             !is.na(Result)) # can remove this once certain no NAs. Maybe remove for Rdata files
-  })
-  
-  
-  # Parameter Selection using ParameterSelect Module
-  Param <- callModule(PARAM_SELECT, "param", Df = Df2, Site = Site)
-  
+TIME_WQ <- function(input, output, session, Df) {
 
-  # Date Range Selection Using DateSelect Module
-  Date_Range <- callModule(DATE_SELECT, "date", Df = Df2, Site = Site)
-  
-  
-  
-  # Reactive Dataframe - filter for param, value range, date, and remove rows with NA for Result
-  Df3 <- reactive({
-    req(Param$Type(), Param$Range_Min(), Param$Range_Min(), Date_Range$Lower(), Date_Range$Upper()) # See General Note _
-    
-    Df2() %>% 
-      filter(Parameter %in% Param$Type(), 
-             Result > Param$Range_Min(), Result < Param$Range_Max(),
-             Date > Date_Range$Lower(), Date < Date_Range$Upper())
-  })
-  
-  
+  ns <- session$ns # see General Note 1
+
   # Plot
-  callModule(PLOT_TIME_WQ, "plot", Df = Df3)
-  
-  
+  callModule(PLOT_TIME_WQ, "plot", Df = Df)
+
+
   # Table
   output$table <- renderDataTable(Df_Table())
-  
-  
+
+
   # Stats
-  callModule(STAT_TIME_WQ, "stats", Df = Df3)
-  
-  
-  # Site Map
-  callModule(SITE_MAP, "site_map", df_site = df_site, Site_List = Site)
-  
-  
+  callModule(STAT_TIME_WQ, "stats", Df = Df)
+
+
   ### Downloadable csv of selected dataset
-  
+
   output$download_data <- downloadHandler(
     filename = function() {
       paste("DCRExportedWQData", ".csv", sep = "")
@@ -168,105 +89,34 @@ TIME_WQ <- function(input, output, session, df_full, Df_Filtered, df_site) {
       write_csv(Df_Table(), file)
     }
   )
-  
-  
+
+
   # Column Selection for table output
   output$column_ui <- renderUI({
-    checkboxGroupInput(ns("column"), "Table Columns:", 
-                       choices = names(Df3()), 
-                       selected = names(Df3()),
+    checkboxGroupInput(ns("column"), "Table Columns:",
+                       choices = names(Df()),
+                       selected = names(Df()),
                        inline = TRUE)
   })
-  
+
   # Df for Table
   Df_Table <- reactive({
     req(input$column)
-    Df3() %>% select(c(input$column))
+    Df() %>% select(c(input$column))
   })
 
-  
-  ### Texts
-  
-  # Text - Filtered Data
-  output$text_filtered <- renderText({
-    req(input$df_choice == "filtered") # See General Note 1
-    'This Dataset has been filtered and therefore some observations (data points) may be excluded.\n See "Filtered tab"'
-  })
-  
-  # Text - Select Site
-  output$text_site_null <- renderText({
-    req(!isTruthy(Site())) # See General Note 1
-    "Select Site(s)"
-  })
-  
-  # Text - Select Param
-  output$text_param_null <- renderText({
-    req(!isTruthy(Param$Type())) # See General Note 1
-    "Select Parameter"
-  })
-  
-  # Text - Select Param
-  output$text_date_null <- renderText({
-    req(!isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper())) # See General Note 1
-    "Select Lower Date Range"
-  })
-  
-  # Text - Number of Samples - Words
-  output$text_num_text <- renderText({
-    req(Df3()) # See General Note 1
-    "Number of Samples in Selected Data:"
-  })
-  
-  # Text - Number of Samples - Number
-  output$text_num <- renderText({
-    req(Df3()) # See General Note 1
-    Df3() %>% summarise(n()) %>% paste()
-  })
-  
-  # Text - Plot- No data Selected
-  output$text_plot_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Plot - Zero data Selected for Plot
-  output$text_plot_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
-  # Text - Table - No data Selected
-  output$text_table_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Table - Zero data Selected
-  output$text_table_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
-  # Text - Stats - No data Selected
-  output$text_stats_no_data <- renderText({
-    req(!isTruthy(Site()) | !isTruthy(Param$Type()) | !isTruthy(Date_Range$Lower()) | !isTruthy(Date_Range$Upper()))
-    "Select Site, Param, and Date"
-  })
-  
-  # Text - Stats - Zero Data Selected
-  output$text_stats_zero_data <- renderText({
-    req(Df3()) # See General Note 1
-    if(Df3() %>% summarise(n()) %>% unlist() == 0){
-      "Selection Contains Zero Observations"
-    }
-  })
-  
-  
 
-  
+
+  # # Text - Zero data Selected for Plot
+  # output$text_zero_data <- renderText({
+  #   req(Df()) # See General Note 1
+  #   if(Df() %>% summarise(n()) %>% unlist() == 0){
+  #     "Selection Contains Zero Observations"
+  #   }
+  # })
+
+
+
+
 } # end Server Function
 

--- a/modules2/inputs/date_select.R
+++ b/modules2/inputs/date_select.R
@@ -14,16 +14,16 @@
 ##############################################################################################################################
 
 DATE_SELECT_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
     # Parameter Selection
     wellPanel(
       uiOutput(ns("date_ui"))
     ) # end Well Panel
   ) # end taglist
-  
+
 } # end UI function
 
 
@@ -31,87 +31,73 @@ DATE_SELECT_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-# Note that Argumetns "Df" and "Site" need to be reactive expressions, not resolved values. 
+# Note that Argument "Df" need to be reactive expressions, not resolved values.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-DATE_SELECT <- function(input, output, session, Df, Site, hidden = FALSE) { 
+DATE_SELECT <- function(input, output, session, Df, hidden = FALSE) {
 
   # Min and Max Dates for Sites Selected
-  
-  Date_Min <- reactive({
-    if(!is.null(Site())){
-      Df() %>% filter(LocationLabel %in% c(Site())) %>%
-        .$Date %>% min(na.rm=TRUE)
-    } else {
-      Df()$Date %>% min(na.rm=TRUE)
-    }
-  })
-  
-  Date_Max <- reactive({
-    if(!is.null(Site())){
-      Df() %>% filter(LocationLabel %in% c(Site())) %>%
-        .$Date %>% max(na.rm=TRUE)
-    } else {
-      Df()$Date %>% max(na.rm=TRUE)
-    }
-  })
-  
-  
+
+  Date_Min <- reactive({Df()$Date %>% min(na.rm=TRUE)})
+
+  Date_Max <- reactive({Df()$Date %>% max(na.rm=TRUE)})
+
+
   # Date Selection UI
-  
+
   output$date_ui <- renderUI({
-    
+
     ns <- session$ns # see General Note 1
 
     # Date Input
-    dateRangeInput(ns("date"), "Date Range:", 
-                   start = Date_Min(), 
-                   end = Date_Max(),  
+    dateRangeInput(ns("date"), "Date Range:",
+                   start = Date_Min(),
+                   end = Date_Max(),
                    min = Date_Min(),
                    max = Date_Max(),
                    startview = "year")
-    
+
   })
-  
-  
+
+
   # To fill back in previously selected
-  
+
   observe({
-    
+
     # save the Parameter Type input for when the Site selection changes. Isolate so does not cause reactivity
     isolate({
         save_selected_lower <- input$date[1]
         save_selected_upper <- input$date[2]
     })
-    
-    # If Site list is changed but not empty then generate a Select Input with the... 
+
+    # If Site list is changed but not empty then generate a Select Input with the...
     # date range for that Site(s) and autoselect previous selected date range
-    if(!is.null(Site())){
-      
-      updateDateRangeInput(session, inputId = "date", label = "Date Range:", 
+    if(Df() %>% summarise(n()) %>% unlist() != 0){
+
+      updateDateRangeInput(session, inputId = "date", label = "Date Range:",
                       start = save_selected_lower,
                       end = save_selected_upper,
                       min = Date_Min(),
                       max = Date_Max())
-    
+
       # If Site list is empty than make a date range of the previously selected date range to save it.
     } else {
-      updateDateRangeInput(session, inputId = "date", label = "Date Range:", 
+      updateDateRangeInput(session, inputId = "date", label = "Date Range:",
                       start = save_selected_lower,
                       end = save_selected_upper,
                       min = save_selected_lower,
                       max = save_selected_upper)
     }
-    
+
   })
-  
 
-  
-  return(list(Lower = reactive({input$date[1]}), 
+
+
+  return(list(Lower = reactive({input$date[1]}),
               Upper = reactive({input$date[2]})))
-  
 
-  
+
+
 } # end Server Function
 

--- a/modules2/inputs/param_select.R
+++ b/modules2/inputs/param_select.R
@@ -14,9 +14,9 @@
 ##############################################################################################################################
 
 PARAM_SELECT_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
     # Parameter Selection
     wellPanel(
@@ -24,7 +24,7 @@ PARAM_SELECT_UI <- function(id) {
       uiOutput(ns("range_ui"))
     ) # end Well Panel
   ) # end taglist
-  
+
 } # end UI function
 
 
@@ -32,12 +32,12 @@ PARAM_SELECT_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-# Note that Arguments "Df"  and "Site" need to be reactive expressions, not resolved values. 
+# Note that Arguments "Df"  and "Site" need to be reactive expressions, not resolved values.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-PARAM_SELECT <- function(input, output, session, Df, Site, multiple = TRUE) { 
-  
+PARAM_SELECT <- function(input, output, session, Df, Site, multiple = TRUE) {
+
 
   # Non Historical Parameters (when a Parameter has not been used in over 5 years). See General Note 6
 
@@ -49,123 +49,121 @@ PARAM_SELECT <- function(input, output, session, Df, Site, multiple = TRUE) {
       levels()
   })
 
-  
-  
+
+
   # Parameter Choice List
-  
+
   Param_Choices <- reactive({
-    
-    if(!is.null(Site())){
-      
+
+    #if(!is.null(Site())){
+
     # Parameters which have data at any Site (in the mofule's Df) within 5 years.
     param_new_choices <- Df() %>%
-      filter(LocationLabel %in% c(Site()),
-             Parameter %in% Parameters_Non_Historical()) %>%
+      filter(Parameter %in% Parameters_Non_Historical()) %>%
       .$Parameter %>%
       factor() %>%
       levels()
-    
+
     # Parameters which do NOT have data at any Site (in the mofule's Df) within 5 years.
     param_old_choices <- Df() %>%
-      filter(LocationLabel %in% c(Site()),
-             !(Parameter %in% Parameters_Non_Historical())) %>%
+      filter(!(Parameter %in% Parameters_Non_Historical())) %>%
       .$Parameter %>%
       factor() %>%
       levels()
-    
+
     # Cmbine lists (recent parameters first and then old parameters)
     c(param_new_choices, param_old_choices)
-    
-    }
-    
+
+    #}
+
   })
-  
 
 
-    
-    
+
+
+
   # Parameter Selection UI
-  
-  
+
+
   output$type_ui <- renderUI({
     ns <- session$ns # see General Note 1
     selectInput(ns("type"), "Parameter:", choices=c(Param_Choices()), multiple = multiple)
   })
-  
-  
-  
+
+
+
   # To fill back in previously selected
-  
+
   observe({
-    
+
     # save the Parameter Type input for when the Site selection changes. Isolate so does not cause reactivity
     isolate({
         save_selected <- input$type
     })
-    
-    # If Site list is changed but not empty then generate a Select Input with the... 
-    # parameters for that Site and autoselect previous selected parameter 
-    if(!is.null(Site())){
-      
-      updateSelectInput(session, inputId = "type", label = "Parameter:", 
+
+    # If Site list is changed but not empty then generate a Select Input with the...
+    # parameters for that Site and autoselect previous selected parameter
+    #if(!is.null(Site())){
+    if(Df() %>% summarise(n()) %>% unlist() != 0){
+
+      updateSelectInput(session, inputId = "type", label = "Parameter:",
                         choices=c(Param_Choices()),
                         selected = save_selected)
-    
+
       # If Site list is empty than make a parameter list of just the previously listed item to save it.
     } else {
-      updateSelectInput(session, inputId = "type", label = "Parameter:", 
+      updateSelectInput(session, inputId = "type", label = "Parameter:",
                         choices= save_selected,
                         selected = save_selected)
     }
-    
+
   })
-  
-  
+
+
   # Units Texts for Selected Parameter
-  
+
   Units <- reactive({
-    
+
     Df() %>%
       filter(Parameter %in% input$type) %>%
       .$Units %>%
       factor() %>%
       levels()
-    
-  })
-  
 
-  
+  })
+
+
+
   # Parameter Value Range Bar UI
-  
+
   output$range_ui <- renderUI({
-    
+
     ns <- session$ns # see General Note 1
-    
-    if(!is.null(Site())){
-      
+
+    #if(!is.null(Site())){
+
       result <- Df() %>%
-        filter(LocationLabel %in% c(Site()),
-               Parameter %in% input$type) %>%
+        filter(Parameter %in% input$type) %>%
         .$Result
-      
+
       param_min <- result %>% min(na.rm=TRUE)
-      
+
       param_max <- result %>% max(na.rm=TRUE)
-      
+
       sliderInput(ns("range"), paste("Range (", Units() , ")"),
                   min = param_min, max = param_max,
                   value = c(param_min, param_max))
-    
-  }
-    
+
+  #}
+
   })
-  
+
   # return List of reactive expressions
-  return(list(Type = reactive({input$type}), 
+  return(list(Type = reactive({input$type}),
               Units = reactive({Units()}), # Units = Units
-              Range_Min = reactive({input$range[1]}), 
+              Range_Min = reactive({input$range[1]}),
               Range_Max = reactive({input$range[2]})))
-  
-  
+
+
 } # end Server Function
 

--- a/modules2/inputs/site_profile.R
+++ b/modules2/inputs/site_profile.R
@@ -1,0 +1,81 @@
+##############################################################################################################################
+#     Title: Site_Profile_UI.R
+#     Type: Module2 for DCR Shiny App
+#     Description: Combined Seleciton Widget for Primary and NonPrimary Site seperation with optional NonPrimary Sites Shown.
+#     Written by: Nick Zinck, Spring 2017
+##############################################################################################################################
+
+# Notes:
+#
+# To-Do List:
+
+##############################################################################################################################
+# User Interface
+##############################################################################################################################
+
+SITE_PROFILE_UI <- function(id) {
+
+  ns <- NS(id) # see General Note 1
+
+  tagList(
+    fluidRow(
+      column(6,
+             # Site Selection
+             wellPanel(
+               CHECKBOX_SELECT_ALL_UI(ns("site"))
+             )
+      ),
+      column(6,
+             wellPanel(
+               uiOutput(ns("level_ui"))
+             ) # end Well Panel
+      )
+    ) # end FluidRow
+  ) # end taglist
+
+} # end UI function
+
+
+##############################################################################################################################
+# Server Function
+##############################################################################################################################
+
+# Note that Argument "Df"  needs to be a reactive expression, not a resolved value.
+# Thus do not use () in callModule argument for reactives
+# For non reactives wrap with "reactive" to make into a reactive expression.
+
+SITE_PROFILE <- function(input, output, session, Df) {
+
+  ns <- session$ns # see General Note 1
+
+  ### Site
+
+  # Choice LIST
+  Site_Choices <- reactive({
+    Df()$LocationLabel %>% factor() %>% levels()
+  })
+
+  # Server
+  Site_Selected <- callModule(CHECKBOX_SELECT_ALL, "site",
+                                 label = "Site:",
+                                 choices = Site_Choices,
+                                 colwidth = 3)
+
+
+
+  ### Location Depth
+
+  # Choices
+  Max_Depth <- reactive({max(Df()$Depthm)})
+
+  # UI
+  output$level_ui <- renderUI({
+    sliderInput(ns("level"), "Depth Range", min = 0, max = Max_Depth(), value = c(0, Max_Depth()))
+  })
+
+
+  return(reactive({list(Site = Site_Selected(),
+                        Depth_Lower = input$level[1],
+                        Depth_Upper = input$level[2])}))
+
+} # end Server Function

--- a/modules2/inputs/station_level_checkbox.R
+++ b/modules2/inputs/station_level_checkbox.R
@@ -14,19 +14,25 @@
 ##############################################################################################################################
 
 STATION_LEVEL_CHECKBOX_UI <- function(id) {
-  
+
   ns <- NS(id) # see General Note 1
-  
+
   tagList(
-    # Site Selection
-    wellPanel(
-      uiOutput(ns("station_ui"))
-    ),
-    wellPanel(
-      uiOutput(ns("level_ui"))
-    ) # end Well Panel
+    fluidRow(
+      column(6,
+             # Site Selection
+             wellPanel(
+               uiOutput(ns("station_ui"))
+             )
+      ),
+      column(6,
+             wellPanel(
+               uiOutput(ns("level_ui"))
+             ) # end Well Panel
+      )
+    ) # end FluidRow
   ) # end taglist
-  
+
 } # end UI function
 
 
@@ -34,19 +40,19 @@ STATION_LEVEL_CHECKBOX_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-# Note that Argument "Df"  needs to be a reactive expression, not a resolved value. 
+# Note that Argument "Df"  needs to be a reactive expression, not a resolved value.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
-STATION_LEVEL_CHECKBOX <- function(input, output, session, Df, selectall = FALSE, colwidth = 3) { 
-  
+STATION_LEVEL_CHECKBOX <- function(input, output, session, Df, selectall = FALSE, colwidth = 3) {
+
   ### Station
-  
+
   # Choice LIST
   Station_Choices <- reactive({
     Df()$Station %>% factor() %>% levels()
   })
-  
+
   Selected1 <- reactive({
     if(selectall == FALSE){
       NULL
@@ -54,13 +60,13 @@ STATION_LEVEL_CHECKBOX <- function(input, output, session, Df, selectall = FALSE
       Station_Choices()
     }
   })
-  
+
   # UI
   output$station_ui <- renderUI({
     ns <- session$ns # see General Note 1
     CHECKBOX_SELECT_ALL_UI(ns("station"))
   })
-  
+
   # Server
   Station_Selected <- callModule(CHECKBOX_SELECT_ALL, "station",
                                  label = "Station:",
@@ -68,15 +74,15 @@ STATION_LEVEL_CHECKBOX <- function(input, output, session, Df, selectall = FALSE
                                  selected = Selected1,
                                  colwidth = colwidth)
 
-  
-  
-  ### Sampling Level
-  
+
+
+  ### Location Depth
+
   # Choices
   Level_Choices <- reactive({
-    Df()$Sampling_Level %>% factor() %>% levels()
+    Df()$LocationDepth %>% factor() %>% levels()
   })
-    
+
   Selected2 <- reactive({
     if(selectall == FALSE){
       NULL
@@ -84,33 +90,33 @@ STATION_LEVEL_CHECKBOX <- function(input, output, session, Df, selectall = FALSE
       level_choices()
     }
   })
-  
+
   # UI
   output$level_ui <- renderUI({
     ns <- session$ns # see General Note 1
     CHECKBOX_SELECT_ALL_UI(ns("level"))
   })
-  
+
   # Server
   Level_Selected <- callModule(CHECKBOX_SELECT_ALL, "level",
                                label = "Sampling Level:",
                                choices = Level_Choices,
                                selected = Selected2,
                                colwidth = colwidth)
-  
-  
+
+
   # Create Site (location Labels) Choices from selected Stations and Levels
   Site_Selected <- reactive({
-    
+
     req(Station_Selected(), Level_Selected())
-    
+
     Df() %>%
       filter(Station %in% Station_Selected(),
-             Sampling_Level %in% Level_Selected()) %>%
+             LocationDepth %in% Level_Selected()) %>%
       .$LocationLabel %>%
       factor() %>%
       levels()
-    
+
   })
 
   return(reactive({Site_Selected()}))

--- a/modules2/outputs/plot_time_wq.R
+++ b/modules2/outputs/plot_time_wq.R
@@ -67,7 +67,7 @@ PLOT_TIME_WQ_UI <- function(id) {
                             sliderInput(ns("point_size"), "Point Size:",
                                         min = 0.5, max = 4, value = 1.5, step = 0.5)
                           )
-                          
+
                         )
                       )
                ), # end column
@@ -91,7 +91,7 @@ PLOT_TIME_WQ_UI <- function(id) {
                                       min = 0, max = 3, value = 1, step = 0.25),
                           sliderInput(ns("trend_alpha"), "Line Opacity:",
                                       min = 0, max = 1, value = .1, step = 0.1)
-                          
+
                         )
                       )
                ) # end column
@@ -121,25 +121,25 @@ PLOT_TIME_WQ_UI <- function(id) {
 # Server Function
 ##############################################################################################################################
 
-# Note that Argument "Df"  needs to be a reactive expression, not a resolved value. 
+# Note that Argument "Df"  needs to be a reactive expression, not a resolved value.
 # Thus do not use () in callModule argument for reactives
 # For non reactives wrap with "reactive" to make into a reactive expression.
 
 PLOT_TIME_WQ <- function(input, output, session, Df) {
 
   ns <- session$ns # see General Note 1
-  
+
 ##################### Main Reactive Expressions
-  
-  # Find Choices for Sites and Param 
+
+  # Find Choices for Param
   Param <- reactive({Df()$Parameter %>% factor() %>% levels()})
-  
+
   # Two Dataframes (Primary and Secondary Axis)
-  
+
   Df1 <- reactive({
     req(input$param1)
     Df() %>% filter(Parameter %in% input$param1)})
-  
+
   Df2 <- reactive({
     req(input$param1) # param1 not param2 in req() becuase param2 always has "None" option
     if(input$param2 != "None"){
@@ -148,7 +148,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
       NULL
     }
   })
-  
+
   # Site List  - Primary Axis Only Plots
   Site <- reactive({
     if(input$param2 == "None"){
@@ -157,7 +157,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
       unique(Df1()$Site %>% factor() %>% levels(), Df2()$Site %>% factor() %>% levels())
     }
   })
-  
+
 ############# Rendered User Interface
 
   # Parameter Axis Choice for Primary Axis
@@ -167,12 +167,12 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                    choices = Param())
     }
   })
-  
+
   outputOptions(output, "param1_ui", suspendWhenHidden = FALSE) # see Dev. Manual
-  
+
   # update when new flag code changes
   observe({
-    
+
     # save previously selected value
     isolate({
       if(input$param1 %in% c(Param())){
@@ -181,24 +181,24 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         save_selected <- NULL
       }
     })
-    
-    updateRadioButtons(session, inputId = "param1", 
+
+    updateRadioButtons(session, inputId = "param1",
                       choices = Param(),
                       selected = save_selected)
   })
-  
+
   # Parameter Axis Choice for Secondary Axis
   output$param2_ui <- renderUI({
     radioButtons(ns("param2"), "Parameter 2 - Secondary Y-Axis",
                  choices = c(Param(), "None"),
                  selected = "None")
   })
-  
+
   outputOptions(output, "param2_ui", suspendWhenHidden = FALSE) # See Dev. Manual
-  
+
   # update when new flag code changes
   observe({
-    
+
     # save previously selected value
     isolate({
       if(input$param2 %in% c(Param(), "None")){
@@ -207,16 +207,16 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         save_selected <- "None"
       }
     })
-    
+
     updateRadioButtons(session, inputId = "param2",
                       choices = c(Param(), "None"),
                       selected = save_selected)
-    
+
   })
 
-  
 
-  
+
+
   # Flag List
   # Flag <- reactive({
   #   if(input$param2 == "None"){
@@ -225,7 +225,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
   #     unique(Df1()$Site %>% factor() %>% levels(), Df2()$Site %>% factor() %>% levels())
   #   }
   # })
-  
+
   # Color Grouping UI
   output$group_color_ui <- renderUI({
     req(input$param2)
@@ -241,47 +241,47 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
       )
     }
   })
-  
+
   # # update when new flag code changes
   # observe({
-  #   
+  #
   #   # save previously selected value
   #   isolate({save_selected <- input$group_color})
-  #   
+  #
   #   #if(input$param2 == "None"){
   #     color_choices <- c("None", "Site", "Flags (needs update)")
-  #     updateRadioButtons(session, inputId = "group_color", label = "Parameter:", 
+  #     updateRadioButtons(session, inputId = "group_color", label = "Parameter:",
   #                       choices=c(color_choices),
   #                       selected = save_selected)
   #   #}
   # })
-  
+
   # Shape Grouping
   output$group_shape_ui <- renderUI({
     req(input$param2)
-    
+
     # Make so this includes all types of flags. Probably make sticky memory
     shape_choices <- c("None/Parameter", "Site", "Flags (needs update)")
-    
+
     radioButtons(ns("group_shape"), label = "Group with Shapes:",
                  choices = shape_choices,
                  selected = "None/Parameter")
   })
-  
+
   # # update when new flag code changes
   # observeEvent(c(Df1(),Df2()), {
-  #   
+  #
   #   # save previously selected value
   #   isolate({save_selected <- input$group_shape})
-  #   
+  #
   #   shape_choices <- c("None/Parameter", "Site", "Flags (needs update)")
-  #   updateRadioButtons(session, inputId = "group_shape", label = "Parameter:", 
+  #   updateRadioButtons(session, inputId = "group_shape", label = "Parameter:",
   #                     choices=c(shape_choices),
   #                     selected = save_selected)
-  #   
+  #
   # })
 
-  
+
   # Axis UI - only show options for 1 Parameter plot
   output$axis_ui <- renderUI({
     req(input$param2 == "None")
@@ -291,7 +291,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                                     "Y-axis start at zero"))
     )
   })
-  
+
   # Point Color 1 UI - only show options when color = None
   output$point_color1_ui <- renderUI({
     req(input$param2 != "None" | input$group_color == "None")
@@ -299,7 +299,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                    choices = c("black", "blue", "red", "green"),
                    inline = TRUE)
   })
-  
+
   # Point Color 2 UI - only show options when color = None
   output$point_color2_ui <- renderUI({
     req(input$param2 != "None")
@@ -316,36 +316,36 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                  choices = c("solid", "dashed", "dotted"),
                  inline = TRUE)
   })
-  
 
-  
+
+
 ########################################################################
 ### Plot UI
-  
-  
-  ### Plot Outputs 
-  
+
+
+  ### Plot Outputs
+
   # ONe Y-axis interactive Plotly plot
   output$plot1_inter <- renderPlotly({
     req(input$param2 == "None")# & P2$Gplotly() == TRUE)
     ggplotly(P5(), tooltip = c("y", "colour", "shape"))
   })
-  
+
   # ONe Y-axis static Plot
   output$plot1_static <- renderPlot({
     req(input$param2 == "None") # & P2$Gplotly() == FALSE)
     P5() + theme(text = element_text(size = 15))
   })
-  
+
   # Two Y-axis ggplot static plot
   output$plot2 <- renderPlot({
     req(input$param2 != "None")
     P5() + theme(text = element_text(size = 15))
   })
-  
+
   output$plot_ui <- renderUI({
     req(input$param1, input$param2)
-    
+
     if(input$param2 != "None"){
       tagList(
         plotOutput(ns("plot2"), width = "100%", height = 600),
@@ -355,35 +355,35 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         plotlyOutput(ns("plot1_inter"), width = "100%", height = 600)
     }else{
         plotOutput(ns("plot1_static"), width = "100%", height = 600)
-    } 
+    }
 
   })
-  
-  
-  
+
+
+
 #########################################################################
 # Plot Creation
-  
+
   # Main Plot Scripts
   P1 <- reactive({
-    
+
     ############# One Parameter Plots - Primary Y axis only ######################################
-    
+
     if(input$param2 == "None"){
-      
+
       p <- ggplot(Df1())
-      
+
       # Group by both Color and Shape when both selected
       if(input$group_color != "None" & input$group_shape != "None/Parameter"){
-          p <- p + geom_point(aes_string(x = "as.POSIXct(Date)", 
-                                         y = "Result", 
-                                         color = input$group_color, 
+          p <- p + geom_point(aes_string(x = "as.POSIXct(Date)",
+                                         y = "Result",
+                                         color = input$group_color,
                                          shape = input$group_shape),
                               size = input$point_size)
           if(input$trend_show == TRUE){
-            p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)", 
-                                            y = "Result", 
-                                            color = input$group_color, 
+            p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)",
+                                            y = "Result",
+                                            color = input$group_color,
                                             linetype = input$group_shape),
                                  method = input$trend_type,
                                  size = input$trend_size,
@@ -393,14 +393,14 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
           }
           # Group by only Color when only color grouping is selected
       } else if (input$group_color != "None"){
-        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)", 
-                                       y = "Result", 
-                                       color = input$group_color), 
+        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)",
+                                       y = "Result",
+                                       color = input$group_color),
                             shape = 16,
                             size = input$point_size)
         if(input$trend_show == TRUE){
-          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)", 
-                                          y = "Result", 
+          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)",
+                                          y = "Result",
                                           color = input$group_color),
                                linetype = input$trend_line,
                                method = input$trend_type,
@@ -411,15 +411,15 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         }
         # Group by only Shape when only shape grouping is selected
       } else if (input$group_shape != "None/Parameter"){
-        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)", 
-                                       y = "Result", 
-                                       shape = input$group_shape), 
+        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)",
+                                       y = "Result",
+                                       shape = input$group_shape),
                             color = input$point_color1,
                             size = input$point_size)
-        
+
         if(input$trend_show == TRUE){
-          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)", 
-                                          y = "Result", 
+          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)",
+                                          y = "Result",
                                           linetype = input$group_shape),
                                method = input$trend_type,
                                size = input$trend_size,
@@ -429,13 +429,13 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         }
         # No Grouping Selected
       } else {
-        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)", 
+        p <- p + geom_point(aes_string(x = "as.POSIXct(Date)",
                                        y = "Result"),
                             color = input$point_color1,
                             shape = 16,
                             size = input$point_size)
         if(input$trend_show == TRUE){
-          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)", 
+          p <- p + geom_smooth(aes_string(x = "as.POSIXct(Date)",
                                           y = "Result"),
                                linetype = input$trend_line,
                                method = input$trend_type,
@@ -445,13 +445,13 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                                level = as.numeric(input$trend_conf))
         }
       }
-      
-      
+
+
       # Facet for Sites if no grouping for site is selected and number of sites is greater than 1
       if(input$group_color != "Site" & input$group_shape != "Site" & length(c(Site())) > 1){
         p <- p + facet_wrap(~Site, ncol = ceiling(length(c(Site()))/4))
       }
-      
+
       # Log Scale and Y-axis start at zero
       if(input$param2 == "None"){
         if("Log-scale Y-Axis" %in% input$axis){
@@ -466,37 +466,37 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
         }
         # Secondary and Primary Axis (2 Parameter Plots)
       }
-      
+
       ############# Two Parameter Plots - Primary and Secondary Y axes' ######################
     } else{
-      
+
       p <- ggplot()
-      
+
       # Grouped by Shape
       if(input$group_shape != "None/Parameter"){
-        p <- p + geom_point(data = Df1(), 
-                            aes_string(x = "as.POSIXct(Date)", 
-                                       y = "Result", 
+        p <- p + geom_point(data = Df1(),
+                            aes_string(x = "as.POSIXct(Date)",
+                                       y = "Result",
                                        shape = input$group_shape),
                             color = input$point_color1,
                             size = input$point_size*2) +
           geom_point(data = Df2(),
-                     aes_string(x = "as.POSIXct(Date)", 
-                                y = "Result*Mult()", 
-                                shape = input$group_shape), 
+                     aes_string(x = "as.POSIXct(Date)",
+                                y = "Result*Mult()",
+                                shape = input$group_shape),
                      color = input$point_color2,
                      size = input$point_size*2)
         if(input$trend_show == TRUE){
-          p <- p + geom_smooth(data = Df1(), aes_string(x = "as.POSIXct(Date)", 
-                                                        y = "Result", 
+          p <- p + geom_smooth(data = Df1(), aes_string(x = "as.POSIXct(Date)",
+                                                        y = "Result",
                                                         linetype = input$group_shape),
                                color = input$point_color1,
                                method = input$trend_type,
                                size = input$trend_size,
                                alpha = input$trend_alpha,
                                se = input$trend_ribbon,
-                               level = as.numeric(input$trend_conf)) + 
-            geom_smooth(data = Df2(), aes_string(x = "as.POSIXct(Date)", 
+                               level = as.numeric(input$trend_conf)) +
+            geom_smooth(data = Df2(), aes_string(x = "as.POSIXct(Date)",
                                                  y = "Result*Mult()",
                                                  linetype = input$group_shape),
                         color = input$point_color2,
@@ -506,31 +506,31 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                         se = input$trend_ribbon,
                         level = as.numeric(input$trend_conf))
         }
-        # Not Grouped 
+        # Not Grouped
       } else{
-        p <- p + geom_point(data = Df1(), 
-                            aes_string(x = "as.POSIXct(Date)", 
+        p <- p + geom_point(data = Df1(),
+                            aes_string(x = "as.POSIXct(Date)",
                                        y = "Result"),
                             shape = 15,
                             color = input$point_color1,
                             size = input$point_size*2) +
           geom_point(data = Df2(),
-                     aes_string(x = "as.POSIXct(Date)", 
-                                y = "Result*Mult()"), 
+                     aes_string(x = "as.POSIXct(Date)",
+                                y = "Result*Mult()"),
                      shape = 17,
                      color = input$point_color2,
                      size = input$point_size*2)
       }
       if(input$trend_show == TRUE){
-        p <- p + geom_smooth(data = Df1(), aes_string(x = "as.POSIXct(Date)", 
+        p <- p + geom_smooth(data = Df1(), aes_string(x = "as.POSIXct(Date)",
                                                       y = "Result"),
                              linetype = input$trend_line,
                              color = input$point_color1,
                              method = input$trend_type,
                              size = input$trend_size,
                              se = input$trend_ribbon,
-                             level = as.numeric(input$trend_conf)) + 
-          geom_smooth(data = Df2(), aes_string(x = "as.POSIXct(Date)", 
+                             level = as.numeric(input$trend_conf)) +
+          geom_smooth(data = Df2(), aes_string(x = "as.POSIXct(Date)",
                                                y = "Result*Mult()"),
                       linetype = input$trend_line,
                       color = input$point_color2,
@@ -539,33 +539,33 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                       se = input$trend_ribbon,
                       level = as.numeric(input$trend_conf))
       }
-      
-      
+
+
       # Facet for Sites if no grouping for site is selected and number of sites is greater than 1
       if(input$group_shape != "Site" & length(c(Site())) > 1){
         p <- p + facet_wrap(~Site, ncol = ceiling(length(c(Site()))/4))
       }
-      
+
     }
-    
+
     ### All Plots #####
     p <- p + scale_x_datetime(breaks = pretty_breaks(n=12))
-    
+
     p
-    
-  }) 
-      
-      
+
+  })
+
+
 
   # Display OPtions Tab
   P2 <- callModule(PLOT_THEME_AND_HLINE, "theme_hline",
                    P = P1)
-  
+
   # Display OPtions Tab
   P3 <- callModule(PLOT_TEXT_AND_VLINES_TIME, "text_vline",
                    P = P2$Plot)
-  
-  
+
+
   # Title and Labels - returns a list of two reactive expressions. One a plot object and one a text string Sec. Axis label
   P4 <- callModule(PLOT_TITLE_AND_LABELS, "title_label",
                    P = P3,
@@ -574,67 +574,67 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
                    Y_Lab_Auto = reactive({paste(Text_Param1(), " (", Text_Units1(),")", sep= "")}),
                    sec_y_axis = TRUE,
                    Y2_Lab_Auto = reactive({paste(Text_Param2(), " (", Text_Units2(),")", sep= "")}))
-  
-  
+
+
   # Secondary Axis Only (Post Axis Label Naming)
   P5 <- reactive({
-    
+
     p <- P4$Plot()
-    
+
     # Secondary Axis Only
     if(input$param2 != "None"){
       p <- p + scale_y_continuous(breaks = pretty_breaks(), # ylim?
-                                  sec.axis = sec_axis(~./Mult(), breaks = pretty_breaks(), 
+                                  sec.axis = sec_axis(~./Mult(), breaks = pretty_breaks(),
                                                       name = P4$Y2_Lab()))
       # p <- p + theme(text = element_text(size = 15))
-      
+
       p <- p + theme(axis.text.y = element_text(colour = input$point_color1),
                      axis.text.y.right = element_text(colour = input$point_color2))
-      
+
     }
-    
-    p 
-          
+
+    p
+
   }) # end P5
-  
-  
+
+
   # Save Tab and Download Function
   callModule(PLOT_SAVE, "save",
              P = P5,
              Plot_Name = Plot_Name)
-  
-  
+
+
   # Multiplier for Secondary Y-axis
   Mult <- reactive({
-    
+
     y1max <- max(Df1()$Result, na.rm = TRUE)
     y2max <- max(Df2()$Result, na.rm = TRUE)
-    
-    y1max / y2max 
+
+    y1max / y2max
 
   })
-  
-  
+
+
   ### Texts For Plot
-  
+
   Text_Site <- reactive({Site() %>% paste(collapse = ", ")})
-  
+
   Text_Param1 <- reactive({Df1()$Parameter %>% factor() %>% levels() %>% paste()})
-  
+
   Text_Param2 <- reactive({Df2()$Parameter %>% factor() %>% levels() %>% paste()})
-  
+
   Text_Units1 <- reactive({Df1()$Units %>% factor() %>% levels() %>% paste(collapse = ", ")})
-  
+
   Text_Units2 <- reactive({Df2()$Units %>% factor() %>% levels() %>% paste(collapse = ", ")})
-  
+
   Text_Date_Start1 <- reactive({Df1()$Date %>% min(na.rm = TRUE) %>% paste()})
-  
+
   Text_Date_End1 <- reactive({Df1()$Date %>% max(na.rm = TRUE) %>% paste()})
-  
+
   Text_Date_Start2 <- reactive({c(Df1()$Date, Df2()$Date)  %>% min(na.rm = TRUE) %>% paste()})
-  
+
   Text_Date_End2 <- reactive({c(Df1()$Date, Df2()$Date) %>% max(na.rm = TRUE) %>% paste()})
-  
+
   Plot_Name <- reactive({
     if(input$param2 == "None"){
       paste0(Text_Param1(),' at Site(s) ', Text_Site(),
@@ -644,7 +644,7 @@ PLOT_TIME_WQ <- function(input, output, session, Df) {
              ' from ', Text_Date_Start2(),' to ', Text_Date_End2())
     }
   })
-  
+
   # legend for double y-axis plot
   output$plot2text <- renderText({
     paste(input$point_color1, "=", Text_Param1(), " , ", input$point_color2, "=", Text_Param2())


### PR DESCRIPTION
Modified filter_wq to include all the site, parameter, and date inputs. Made this unified for wq, wq depth, and profile data, through an argument called "type"

Put the watershed selection outside of the Side Menu. I also think we could add a column in the config file that would have the App default to either the Wachusett or Quabbin tab to minimize that tab click (right now I just have this value set to “Wachusett”).

got rid of the need for some intermediate modules like “time_wq”, “corr_wq”, etc. which significantly cuts code repetition.

